### PR TITLE
Export tokenizer and environment

### DIFF
--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -12,6 +12,7 @@ await build({
   entryPoints: [
     "./mod.ts",
     "./src/environment.ts",
+    "./src/loader.ts",
     "./src/tokenizer.ts",
     "./plugins/auto_trim.ts",
   ],

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -9,7 +9,12 @@ if (!version) {
 }
 
 await build({
-  entryPoints: ["./mod.ts", "./plugins/auto_trim.ts"],
+  entryPoints: [
+    "./mod.ts",
+    "./src/environment.ts",
+    "./src/tokenizer.ts",
+    "./plugins/auto_trim.ts",
+  ],
   outDir: "./npm",
   shims: { deno: true },
   compilerOptions: { target: "ES2022" },


### PR DESCRIPTION
Was working on a plugin for Vento that I also wanted to publish to npm. However, the types for it aren't exported anywhere in package.json, so I've added tokenizer and environment as entrypoints. Maybe could add loader too if that makes sense.