### PR TITLE
Remove `with` usage in generated code, add code transform step

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,7 @@
 export * as path from "https://deno.land/std@0.210.0/path/mod.ts";
 export * as html from "https://deno.land/std@0.210.0/html/mod.ts";
+
+export * as astring from "https://deno.land/x/astring@v1.8.6/src/astring.js";
+export * as meriyah from "npm:meriyah";
+export * as walker from "npm:estree-walker";
+export type * as ESTree from "npm:@types/estree";

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -16,8 +16,18 @@ await build({
     "./src/tokenizer.ts",
     "./plugins/auto_trim.ts",
   ],
+  scriptModule: false,
   outDir: "./npm",
-  shims: { deno: true },
+  shims: {
+    deno: true,
+    custom: [{
+      package: {
+        name: "@types/estree",
+        version: "^1.0.0",
+      },
+      globalNames: [],
+    }],
+  },
   compilerOptions: { target: "ES2022" },
   typeCheck: "both",
   package: {
@@ -28,6 +38,9 @@ await build({
     repository: "github:oscarotero/vento",
     homepage: "https://vento.js.org/",
     bugs: "https://github.com/oscarotero/vento/issues",
+  },
+  mappings: {
+    "npm:@types/estree": "estree",
   },
   postBuild() {
     Deno.copyFileSync("LICENSE", "npm/LICENSE");

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -18,16 +18,7 @@ await build({
   ],
   scriptModule: false,
   outDir: "./npm",
-  shims: {
-    deno: true,
-    custom: [{
-      package: {
-        name: "@types/estree",
-        version: "^1.0.0",
-      },
-      globalNames: [],
-    }],
-  },
+  shims: { deno: true },
   compilerOptions: { target: "ES2022" },
   typeCheck: "both",
   package: {
@@ -38,6 +29,9 @@ await build({
     repository: "github:oscarotero/vento",
     homepage: "https://vento.js.org/",
     bugs: "https://github.com/oscarotero/vento/issues",
+    devDependencies: {
+      "@types/estree": "^1.0.0",
+    },
   },
   mappings: {
     "npm:@types/estree": "estree",

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,4 +1,4 @@
-import { ESTree, astring, meriyah, walker } from "../deps.ts";
+import { astring, ESTree, meriyah, walker } from "../deps.ts";
 
 // List of identifiers that are in globalThis
 // but should be accessed as templateState.identifier
@@ -9,12 +9,12 @@ const INCLUDE_GLOBAL = [
 // List of identifiers that should be ignored
 // when transforming the code
 const DEFAULT_EXCLUDES = [
-    "globalThis",
-    "self",
-    "global",
-    "this",
-    "undefined",
-    "null",
+  "globalThis",
+  "self",
+  "global",
+  "this",
+  "undefined",
+  "null",
 ];
 
 type Scope = {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,0 +1,208 @@
+import { ESTree, astring, meriyah, walker } from "../deps.ts";
+
+// List of identifiers that are in globalThis
+// but should be accessed as templateState.identifier
+const INCLUDE_GLOBAL = [
+  "name",
+];
+
+// List of identifiers that should be ignored
+// when transforming the code
+const DEFAULT_EXCLUDES = [
+    "globalThis",
+    "self",
+    "global",
+    "this",
+    "undefined",
+    "null",
+];
+
+type Scope = {
+  globalScope: number;
+  stack: string[];
+};
+
+// Tracks the scope of the code
+// and the variables that should be ignored
+class ScopeTracker {
+  private scopes: Scope[] = [];
+
+  // The index of the global/function scope
+  private globalScope = 0;
+  globalDeclaration = false;
+
+  includes(val: string): boolean {
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      if (this.scopes[i].stack.includes(val)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  pushScope(global?: boolean) {
+    if (global) {
+      this.globalScope = this.scopes.length;
+    }
+
+    const newScope: Scope = {
+      globalScope: this.globalScope,
+      stack: [],
+    };
+
+    this.scopes.push(newScope);
+  }
+
+  popScope() {
+    this.globalScope = this.scopes[this.scopes.length - 1].globalScope;
+    this.scopes.pop();
+  }
+
+  pushBinding(val: string) {
+    if (this.scopes.length === 0) {
+      this.scopes.push({ globalScope: this.globalScope, stack: [] });
+    }
+
+    if (this.globalDeclaration) {
+      this.scopes[this.globalScope].stack.push(val);
+    } else {
+      this.scopes[this.scopes.length - 1].stack.push(val);
+    }
+  }
+
+  pushPatternBinding(pattern: ESTree.Pattern) {
+    switch (pattern.type) {
+      case "Identifier":
+        this.pushBinding(pattern.name);
+        break;
+
+      case "RestElement":
+        this.pushPatternBinding(pattern.argument);
+        break;
+
+      case "ArrayPattern":
+        for (const element of pattern.elements) {
+          if (element) {
+            this.pushPatternBinding(element);
+          }
+        }
+        break;
+
+      case "ObjectPattern":
+        for (const prop of pattern.properties) {
+          if (prop.type === "RestElement") {
+            this.pushPatternBinding(prop.argument);
+          } else {
+            this.pushPatternBinding(prop.value);
+          }
+        }
+        break;
+
+      case "AssignmentPattern":
+        this.pushPatternBinding(pattern.left);
+        break;
+    }
+  }
+
+  pushPatterns(patterns: ESTree.Pattern[]) {
+    for (const pattern of patterns) {
+      this.pushPatternBinding(pattern);
+    }
+  }
+}
+
+export function transformTemplateCode(
+  code: string,
+  templateState: string,
+): string {
+  const parsed = meriyah.parseScript(code, { module: true }) as ESTree.Program;
+  const tracker = new ScopeTracker();
+
+  const exclude = [
+    templateState,
+    ...DEFAULT_EXCLUDES,
+  ];
+
+  if (parsed.type !== "Program") {
+    throw new Error("Expected a program");
+  }
+
+  if (parsed.body.length === 0) {
+    throw new Error("Empty program");
+  }
+
+  function transformIdentifier(
+    id: ESTree.Identifier,
+  ): ESTree.MemberExpression | ESTree.Identifier {
+    if (
+      (!INCLUDE_GLOBAL.includes(id.name) &&
+        globalThis[id.name as keyof typeof globalThis] !== undefined) ||
+      exclude.includes(id.name) ||
+      tracker.includes(id.name) ||
+      id.name.startsWith("__")
+    ) {
+      return id;
+    }
+
+    return {
+      type: "MemberExpression",
+      object: {
+        type: "Identifier",
+        name: templateState,
+      },
+      optional: false,
+      computed: false,
+      property: id,
+    };
+  }
+
+  walker.walk(parsed, {
+    enter(node) {
+      switch (node.type) {
+        case "VariableDeclaration":
+          tracker.globalDeclaration = node.kind === "var";
+          tracker.pushPatterns(node.declarations.map((d) => d.id));
+          tracker.globalDeclaration = false;
+          break;
+
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+          if (node.id) {
+            tracker.pushBinding(node.id.name);
+          }
+          tracker.pushScope(true);
+          tracker.pushPatterns(node.params);
+          break;
+
+        case "ArrowFunctionExpression":
+          tracker.pushScope();
+          tracker.pushPatterns(node.params);
+          break;
+      }
+    },
+    leave(node, parent) {
+      switch (node.type) {
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+        case "ArrowFunctionExpression":
+          tracker.popScope();
+          break;
+
+        case "Identifier":
+          if (parent?.type === "MemberExpression" && parent.property === node) {
+            return;
+          }
+          if (parent?.type === "Property" && parent.key === node) {
+            return;
+          }
+          this.replace(transformIdentifier(node));
+          break;
+      }
+    },
+  });
+
+  const generated = astring.generate(parsed);
+
+  return generated;
+}

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -104,7 +104,7 @@ class ScopeTracker {
     }
   }
 
-  pushPatterns(patterns: ESTree.Pattern[], global?: boolean) {
+  pushPatternBindings(patterns: ESTree.Pattern[], global?: boolean) {
     for (const pattern of patterns) {
       this.pushPatternBinding(pattern, global);
     }
@@ -167,7 +167,7 @@ export function transformTemplateCode(
         // Track variable declarations
         case "VariableDeclaration":
           // "var" declarations are scoped to the function/global scope.
-          tracker.pushPatterns(
+          tracker.pushPatternBindings(
             node.declarations.map((d) => d.id),
             node.kind === "var",
           );
@@ -182,12 +182,12 @@ export function transformTemplateCode(
             tracker.pushBinding(node.id.name);
           }
           tracker.pushScope(true);
-          tracker.pushPatterns(node.params);
+          tracker.pushPatternBindings(node.params);
           break;
 
         case "ArrowFunctionExpression":
           tracker.pushScope();
-          tracker.pushPatterns(node.params);
+          tracker.pushPatternBindings(node.params);
           break;
       }
     },


### PR DESCRIPTION
## Motivation
The `with` statement comes with a lot of caveats, the main one (for me) is the huge performance penalty. JavaScript runtimes will de-optimize value accesses inside of `with` statements. I like the convenience of accessing state properties with just `{{ prop }}`, but since it has a huge perf penalty, I usually opt to disable `useWith`, which forces me to write templates with `it`.

Additionally, the generated code can't be used in strict mode.

## Solution

Remove the `with` statement, and rewrite the generated JavaScript to insert the template state access.

Currently, it happens in a (~200 LoC) transform step that analyzes the AST of the generated code, and rewrites any unbound and non-global values to access from the template state. Accessing globals like `Deno`, `Promise`, `JSON` and other globals should still work to try and keep the "write real JavaScript" promise, and it should also respect variable bindings and their scopes.

## Benchmarks

Quick benchmark to guage the improvement, it varies a bit (mostly on accesses inside the `with` statement)

| Rank | Engine                  | Time      | Times Slower |
|------|-------------------------|-----------|--------------|
| 1    | String Template         | 138.114ms | 1.00x        |
| 2    | Vento (new)             | 164.576ms | 1.192x       |
| 3    | Vento (useWith = false) | 166.130ms | 1.203x       |
| 4    | Vento (old)             | 941.945ms | 6.820x       |

With the code transform step, Vento now performs within error of disabling `useWith`. The real-world improvements can be pretty huge for SSR use-cases, especially in larger templates (though this varies on accesses!).

## Todo

- [x] Parse code into AST
- [x] Track variable bindings and scope (while also respecting `var`)
- [x] Rewrite non-global, unbound accesses to access from template state
- [x] Pass existing tests
- [ ] Add tests for scope binding checks, global accesses and other potential edge-cases
- ~~Replace `estree-walker` so we can still build CJS modules (maybe?)~~