### PR TITLE
Fix nested layouts

### DIFF
--- a/plugins/layout.ts
+++ b/plugins/layout.ts
@@ -28,8 +28,8 @@ function layoutTag(
   const [_, file, data] = match;
 
   const varname = output.startsWith("__layout")
-  ? output + "_layout"
-  : "__layout";
+    ? output + "_layout"
+    : "__layout";
 
   const compiled: string[] = [];
   const compiledFilters = env.compileFilters(tokens, varname);

--- a/plugins/layout.ts
+++ b/plugins/layout.ts
@@ -27,7 +27,13 @@ function layoutTag(
 
   const [_, file, data] = match;
 
-  const varname = "__content";
+  let varname
+  if (output.startsWith("__layout")) {
+    varname = output + "_layout";
+  } else {
+    varname = "__layout";
+  }
+
   const compiled: string[] = [];
   const compiledFilters = env.compileFilters(tokens, varname);
 

--- a/plugins/layout.ts
+++ b/plugins/layout.ts
@@ -27,12 +27,9 @@ function layoutTag(
 
   const [_, file, data] = match;
 
-  let varname
-  if (output.startsWith("__layout")) {
-    varname = output + "_layout";
-  } else {
-    varname = "__layout";
-  }
+  const varname = output.startsWith("__layout")
+  ? output + "_layout"
+  : "__layout";
 
   const compiled: string[] = [];
   const compiledFilters = env.compileFilters(tokens, varname);

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -60,3 +60,15 @@ Deno.test("Layout tag (with extra data and filters)", async () => {
     },
   });
 });
+
+Deno.test("Nested layout tags", async () => {
+  await test({
+    template: `
+    {{ layout "/my-file.tmpl" }}{{ layout "/my-file.tmpl" }}Hello world{{ /layout }}{{ /layout }}
+    `,
+    expected: "<h1><h1>Hello world</h1></h1>",
+    includes: {
+      "/my-file.tmpl": "<h1>{{ content }}</h1>",
+    },
+  });
+});


### PR DESCRIPTION
This is probably a weird use of layouts (I'm kinda using them like components). However, since most of my templates are already in a layout, this didn't work since it was just outputting to itself (the `__content` variable shadows the parent, which also is a layout setting the output var to `__content`).

Also added a test for this.