### PR TITLE
Fix object property shorthand

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -193,6 +193,20 @@ export function transformTemplateCode(
           tracker.pushScope();
           tracker.pushPatternBindings(node.params);
           break;
+
+        case "Property":
+          if (node.shorthand && node.key.type === "Identifier") {
+            this.replace({
+              type: "Property",
+              key: node.key,
+              value: transformIdentifier(node.key),
+              kind: "init",
+              computed: false,
+              method: false,
+              shorthand: false,
+            });
+          }
+          break;
       }
     },
     leave(node, parent) {

--- a/test/include.test.ts
+++ b/test/include.test.ts
@@ -240,3 +240,19 @@ Deno.test("Include tag dynamically", async () => {
     },
   });
 });
+
+// Test for https://github.com/ventojs/vento/issues/49
+Deno.test("Include tag with object shorthand syntax", async () => {
+  await test({
+    template: `
+    {{ include "/my-file.tmpl" { name } }}
+    `,
+    expected: "Hello Vento",
+    includes: {
+      "/my-file.tmpl": "Hello {{ name }}",
+    },
+    data: {
+      name: "Vento",
+    },
+  });
+});


### PR DESCRIPTION
Fixes #49. This will transform instances of:
```js
{
  name
}
```
into
```js
{
  name: it.name
}
```