### PR TITLE
skip deployment in PR

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -43,12 +43,13 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v2
-      
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
           path: 'docs/_site'
 
       - name: Deploy to GitHub Pages
+        if: ${{ github.event_name == 'push' }}
         id: deployment
         uses: actions/deploy-pages@v1


### PR DESCRIPTION
This can avoid errors like something occurred in https://github.com/ventojs/vento/actions/runs/8536415391/job/23384881018?pr=53 .