### PR TITLE
Typo Fix: correct echo tag function name

### DIFF
--- a/plugins/echo.ts
+++ b/plugins/echo.ts
@@ -3,11 +3,11 @@ import type { Environment, Plugin } from "../src/environment.ts";
 
 export default function (): Plugin {
   return (env: Environment) => {
-    env.tags.push(setTag);
+    env.tags.push(echoTag);
   };
 }
 
-function setTag(
+function echoTag(
   env: Environment,
   code: string,
   output: string,


### PR DESCRIPTION
Quick correction of a typo I noticed last week while writing my integration. Looks like the `echo` tag declaration was named `set` by accident.