### PR TITLE
Updates for Deno 2

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'docs/_site'
+          path: "docs/_site"
 
       - name: Deploy to GitHub Pages
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Verify formatting
         run: deno fmt --check

--- a/.github/workflows/jsr.yml
+++ b/.github/workflows/jsr.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Publish to JSR
         run: |

--- a/.github/workflows/jsr.yml
+++ b/.github/workflows/jsr.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 permissions:
   contents: read

--- a/_scripts/build_npm.ts
+++ b/_scripts/build_npm.ts
@@ -1,5 +1,5 @@
-import { build } from "jsr:@deno/dnt@0.41.2";
-import { emptyDir } from "jsr:@std/fs@0.229.3/empty-dir";
+import { build } from "jsr:@deno/dnt@0.41.3";
+import { emptyDir } from "jsr:@std/fs@1.0.4/empty-dir";
 
 await emptyDir("./_npm");
 
@@ -35,7 +35,7 @@ await build({
     },
   },
   mappings: {
-    "npm:@types/estree@1.0.5": "estree",
+    "npm:@types/estree@1.0.6": "estree",
   },
   postBuild() {
     Deno.copyFileSync("LICENSE", "_npm/LICENSE");

--- a/bench/bench.ts
+++ b/bench/bench.ts
@@ -1,7 +1,7 @@
 import vento from "../mod.ts";
 import nunjucks from "npm:nunjucks@3.2.4";
-import { Liquid } from "npm:liquidjs@10.15.0";
-import { Eta } from "https://deno.land/x/eta@v3.4.0/src/index.ts";
+import { Liquid } from "npm:liquidjs@10.18.0";
+import { Eta } from "https://deno.land/x/eta@v3.5.0/src/index.ts";
 
 const env = vento({
   useWith: true,

--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
     "docs": "cd docs && deno task serve",
     "build-npm": "deno run --allow-run=npm --allow-env --allow-sys --allow-read --allow-write --allow-net=jsr.io _scripts/build_npm.ts",
     "build-jsr": "deno run -A https://deno.land/x/jsrx@v0.1.1/mod.ts --name=@vento/vento",
-    "update-deps": "rm -rf npm && deno run -A 'https://deno.land/x/nudd@v0.2.6/cli.ts' update deno.json **/*.ts"
+    "update-deps": "rm -rf npm && deno run -A 'https://deno.land/x/nudd@v0.2.8/cli.ts' update deno.json **/*.ts"
   },
   "lock": false,
   "fmt": {

--- a/deps.ts
+++ b/deps.ts
@@ -1,7 +1,7 @@
-export * as path from "jsr:@std/path@1.0.0";
-export * as html from "jsr:@std/html@1.0.0";
+export * as path from "jsr:@std/path@1.0.6";
+export * as html from "jsr:@std/html@1.0.3";
 
 export * as astring from "jsr:@davidbonnet/astring@1.8.6";
-export * as meriyah from "npm:meriyah@4.5.0";
+export * as meriyah from "npm:meriyah@6.0.2";
 export * as walker from "npm:estree-walker@3.0.3";
-export type * as ESTree from "npm:@types/estree@1.0.5";
+export type * as ESTree from "npm:@types/estree@1.0.6";

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -91,7 +91,7 @@ export default function tokenize(source: string): TokenizeResult {
       }
     }
   } catch (error) {
-    return { tokens, position, error };
+    return { tokens, position, error: error as Error | undefined };
   }
 
   return { tokens, position, error: undefined };


### PR DESCRIPTION
In prep for tackling #78, I have updated dependencies and also needed to handle a type assertion case because of how Typescript in Deno 2 handles error parameters in a `try ... catch` statement. This pull should bring everything up-to-date for running in Deno v2.

Hopefully nothing vastly breaking here but thought it best to open a seperate pull for these changes as they don't relate to #78.