### PR TITLE
Improve transform error handling with compiled function annotations

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export * as path from "jsr:@std/path@1.0.8";
+export * as path from "https://deno.land/std@0.224.0/path/mod.ts";
 export * as html from "jsr:@std/html@1.0.3";
 
 export * as astring from "jsr:@davidbonnet/astring@1.8.6";

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -139,8 +139,9 @@ export class Environment {
       try {
         code = transformTemplateCode(code, dataVarname);
       } catch (error) {
-        const end = (error as ParseError).start;
-        const lastPos = code.slice(0, end).lastIndexOf("__pos = ");
+        let { start: errorStart, message, annotation } = error as ParseError;
+        
+        const lastPos = code.slice(0, errorStart).lastIndexOf("__pos = ");
         const lastPosEnd = code.slice(lastPos).indexOf(";");
 
         if (lastPos > -1 && lastPosEnd > lastPos) {
@@ -148,11 +149,16 @@ export class Environment {
             code.slice(lastPos + 8, lastPos + lastPosEnd),
             10,
           );
+
+          if (annotation) {
+            message += `\n\nAttempted to parse:\n\n${annotation}`
+          }
+
           throw this.createError(
             path || "",
             source,
             pos,
-            new Error((error as ParseError).message),
+            new Error(message),
           );
         }
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,7 +1,7 @@
 import tokenize, { Token } from "./tokenizer.ts";
 
 import type { Loader } from "./loader.ts";
-import { transformTemplateCode } from "./transformer.ts";
+import { transformTemplateCode, type ParseError} from "./transformer.ts";
 
 export interface TemplateResult {
   content: string;
@@ -387,8 +387,4 @@ function checkAsync(fn: () => unknown): boolean {
   return fn.constructor?.name === "AsyncFunction";
 }
 
-interface ParseError extends Error {
-  start: number;
-  end: number;
-  range: [number, number];
-}
+

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -320,7 +320,7 @@ export class Environment {
     const [line, column, code] = errorLine(source, position);
 
     return new Error(
-      `Error in the template ${path}:${line}:${column}\n\n${code.trim()}\n\n> ${cause.message}\n`,
+      `Error in the template ${path}:${line}:${column}\n\n${code.trim()}\n\n${cause.message.replaceAll(/^/gm, '> ')}\n`,
       { cause },
     );
   }

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,7 +1,7 @@
 import tokenize, { Token } from "./tokenizer.ts";
 
 import type { Loader } from "./loader.ts";
-import { transformTemplateCode, type ParseError} from "./transformer.ts";
+import { type ParseError, transformTemplateCode } from "./transformer.ts";
 
 export interface TemplateResult {
   content: string;
@@ -139,8 +139,8 @@ export class Environment {
       try {
         code = transformTemplateCode(code, dataVarname);
       } catch (error) {
-        let { start: errorStart, message, annotation } = error as ParseError;
-        
+        const { start: errorStart, message } = error as ParseError;
+
         const lastPos = code.slice(0, errorStart).lastIndexOf("__pos = ");
         const lastPosEnd = code.slice(lastPos).indexOf(";");
 
@@ -149,10 +149,6 @@ export class Environment {
             code.slice(lastPos + 8, lastPos + lastPosEnd),
             10,
           );
-
-          if (annotation) {
-            message += `\n\nAttempted to parse:\n\n${annotation}`
-          }
 
           throw this.createError(
             path || "",
@@ -392,5 +388,3 @@ export function errorLine(
 function checkAsync(fn: () => unknown): boolean {
   return fn.constructor?.name === "AsyncFunction";
 }
-
-

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -140,7 +140,7 @@ export class Environment {
         code = transformTemplateCode(code, dataVarname);
       } catch (error) {
         if (error instanceof TransformError) {
-          throw this.createError(path || "", source, error.pos, error);
+          throw this.createError(path, source, error.pos, error);
         }
 
         throw error;
@@ -179,7 +179,7 @@ export class Environment {
     const { position, error } = result;
 
     if (error) {
-      throw this.createError(path || "unknown", source, position, error);
+      throw this.createError(path, source, position, error);
     }
 
     for (const tokenPreprocessor of this.tokenPreprocessors) {
@@ -312,15 +312,11 @@ export class Environment {
   }
 
   createError(
-    path: string,
-    source: string,
-    position: number,
+    path: string = "unknown",
+    source: string = "<empty file>",
+    position: number = 0,
     cause: Error,
   ): Error {
-    if (!source) {
-      return cause;
-    }
-
     const [line, column, code] = errorLine(source, position);
 
     return new Error(

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -320,7 +320,9 @@ export class Environment {
     const [line, column, code] = errorLine(source, position);
 
     return new Error(
-      `Error in the template ${path}:${line}:${column}\n\n${code.trim()}\n\n${cause.message.replaceAll(/^/gm, '> ')}\n`,
+      `Error in the template ${path}:${line}:${column}\n\n${code.trim()}\n\n${
+        cause.message.replaceAll(/^/gm, "> ")
+      }\n`,
       { cause },
     );
   }

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -157,7 +157,7 @@ export function transformTemplateCode(
 
     throw new TransformError({
       message:
-        `Failed to transform template function internally.\n${message} while transforming:\n\n${annotation}`,
+        `Error transforming template function.\n${message} while transforming:\n\n${annotation}`,
       cause: error as ParseError,
       pos,
     });

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -147,9 +147,14 @@ export function transformTemplateCode(
   } catch (error) {
     const { message, start, loc } = error as ParseError;
 
+    // Use information from `meriyah` to annotate the part of
+    // the compiled template function that triggered the ParseError
     const annotation = code.split("\n")[loc.start.line - 1] + "\n" +
       " ".repeat(loc.start.column) + "\x1b[31m^\x1b[0m";
 
+    // Grab the last instance of Vento's `__pos` variable before the
+    // error was thrown. Pass this back to Vento's createError to
+    // tie this error with problmatic template code
     const matches = [...code.slice(0, start).matchAll(/__pos = (\d+);/g)];
     const pos = Number(matches.at(-1)?.[1]);
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -166,7 +166,7 @@ export function transformTemplateCode(
   }
 
   walker.walk(parsed, {
-    enter(node) {
+    enter(node: ESTree.Node) {
       switch (node.type) {
         // Track variable declarations
         case "VariableDeclaration":

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -150,8 +150,8 @@ export function transformTemplateCode(
     const annotation = code.split("\n")[loc.start.line - 1] + "\n" +
       " ".repeat(loc.start.column) + "\x1b[31m^\x1b[0m";
 
-    const posMatches = [...code.slice(0, start).matchAll(/__pos = (\d+);/g)];
-    const pos = Number(posMatches.at(-1)?.[1]);
+    const matches = [...code.slice(0, start).matchAll(/__pos = (\d+);/g)];
+    const pos = Number(matches.at(-1)?.[1]);
 
     throw new TransformError(
       `Error transforming template function.\n${message} while transforming:\n\n${annotation}`,

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -9,18 +9,16 @@ interface ParseError extends Error {
   description: string;
 }
 
-interface TransformErrorOptions {
-  message: string;
-  pos: number;
-  cause: Error;
+interface TransformErrorOptions extends ErrorOptions {
+  pos?: number;
 }
 
 export class TransformError extends Error {
-  pos: number;
-  constructor(options: TransformErrorOptions) {
-    super(options.message, { cause: options.cause });
+  pos?: number;
+  constructor(message: string, options?: TransformErrorOptions) {
+    super(message);
     this.name = "TransformError";
-    this.pos = options.pos;
+    this.pos = options?.pos;
   }
 }
 
@@ -155,12 +153,10 @@ export function transformTemplateCode(
     const posMatches = [...code.slice(0, start).matchAll(/__pos = (\d+);/g)];
     const pos = Number(posMatches.at(-1)?.[1]);
 
-    throw new TransformError({
-      message:
-        `Error transforming template function.\n${message} while transforming:\n\n${annotation}`,
-      cause: error as ParseError,
-      pos,
-    });
+    throw new TransformError(
+      `Error transforming template function.\n${message} while transforming:\n\n${annotation}`,
+      { cause: error as ParseError, pos },
+    );
   }
 
   const tracker = new ScopeTracker();

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,5 +1,15 @@
 import { astring, ESTree, meriyah, walker } from "../deps.ts";
 
+// Declare types
+export interface ParseError extends Error {
+  start: number;
+  end: number;
+  range: [number, number];
+  loc: Record<'start' | 'end', Record<'line' | 'column', number>>;
+  description: string;
+  annotation?: string;
+}
+
 // List of identifiers that are in globalThis
 // but should be accessed as templateState.identifier
 const INCLUDE_GLOBAL = [

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -154,8 +154,8 @@ export function transformTemplateCode(
     const pos = Number(matches.at(-1)?.[1]);
 
     throw new TransformError(
-      `Error transforming template function.\n${message} while transforming:\n\n${annotation}`,
-      { cause: error as ParseError, pos },
+      `[meriyah] ${message}\nthrown while parsing compiled template function:\n\n${annotation}`,
+      { pos },
     );
   }
 
@@ -167,11 +167,11 @@ export function transformTemplateCode(
   ];
 
   if (parsed.type !== "Program") {
-    throw new Error("Expected a program");
+    throw new TransformError("[meriyah] Expected a program");
   }
 
   if (parsed.body.length === 0) {
-    throw new Error("Empty program");
+    throw new TransformError("[meriyah] Empty program");
   }
 
   // Transforms an identifier to a MemberExpression


### PR DESCRIPTION
Here's an attempt to further improve #85. I'm not super happy with the implementation, since it feels like transform errors and template errors should be handled seperately. I didn't want to start refactoring everything so I tried to make these edits as reviewable as possible and keep the discussion going.

My reasoning for adding an annotated message logging the line of the compiled template function was to explain the errors that `meriyah` might throw and make it clear that the error is happening on a **compiled** function, not a user-authored one. To deal with these errors originating from the Eleventy integration, I also plan to add a message to my plugin reminding users to check for undeclared shortcodes and filters since those will cause errors when `meriyah` goes to parse/transform.

Happy to edit/revise further if there's a cleaner way of tracking these errors!

---

Also included in this pull:

- 871cb1bf04e6d429f7ed1a3ce3471774425084f1 adds type annotation for ESTree nodes so Typescript can pick those up.
- 5279c7db25ca71cbd01cc9fdcdc0ebee5b7386c6 patches a build error I was getting with `dnt` and JSR, for whatever reason, `dnt` was complaining that `@std/path@1.0.8` wasn't able to be resolved. Reverting to the `deno.land` url fixes this for now.