### PR TITLE
Implement `TransformError`/`TemplateError` subclasses

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "deno.enable": true,
   "deno.unstable": true,
   "deno.importMap": "./docs/deno.json",
-  "prettier.enable": false
+  "prettier.enable": false,
+  "editor.defaultFormatter": "denoland.vscode-deno"
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,66 @@
+class VentoError extends Error {
+  constructor(
+    message?: string,
+    public override cause?: Error,
+  ) {
+    super(message);
+    Error?.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+  }
+}
+
+export class TemplateError extends VentoError {
+  constructor(
+    public path: string = "<unknown>",
+    public source: string = "<empty file>",
+    public position: number = 0,
+    cause?: Error,
+  ) {
+    const { line, column, code } = errorLine(source, position);
+    super(
+      `Error in template ${path}:${line}:${column}\n\n${code.trim()}\n\n`,
+      cause,
+    );
+
+    if (cause) {
+      this.message += `(via ${cause.name})\n`;
+    }
+  }
+}
+
+export class TransformError extends VentoError {
+  constructor(
+    message: string,
+    public position: number = 0,
+    cause?: Error,
+  ) {
+    super(message, cause);
+  }
+}
+
+/** Returns the number and code of the errored line */
+export function errorLine(
+  source: string,
+  position: number,
+): { line: number; column: number; code: string } {
+  let line = 1;
+  let column = 1;
+
+  for (let index = 0; index < position; index++) {
+    if (
+      source[index] === "\n" ||
+      (source[index] === "\r" && source[index + 1] === "\n")
+    ) {
+      line++;
+      column = 1;
+
+      if (source[index] === "\r") {
+        index++;
+      }
+    } else {
+      column++;
+    }
+  }
+
+  return { line, column, code: source.split("\n")[line - 1] };
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,15 +1,8 @@
-class VentoError extends Error {
-  constructor(
-    message?: string,
-    public override cause?: Error,
-  ) {
-    super(message);
-    Error?.captureStackTrace(this, this.constructor);
-    this.name = this.constructor.name;
-  }
+class VentoBaseError extends Error {
+  override name = this.constructor.name;
 }
 
-export class TemplateError extends VentoError {
+export class TemplateError extends VentoBaseError {
   constructor(
     public path: string = "<unknown>",
     public source: string = "<empty file>",
@@ -19,7 +12,7 @@ export class TemplateError extends VentoError {
     const { line, column, code } = errorLine(source, position);
     super(
       `Error in template ${path}:${line}:${column}\n\n${code.trim()}\n\n`,
-      cause,
+      { cause },
     );
 
     if (cause) {
@@ -28,13 +21,13 @@ export class TemplateError extends VentoError {
   }
 }
 
-export class TransformError extends VentoError {
+export class TransformError extends VentoBaseError {
   constructor(
     message: string,
     public position: number = 0,
     cause?: Error,
   ) {
-    super(message, cause);
+    super(message, { cause });
   }
 }
 


### PR DESCRIPTION
Ok! Here's the PR for the `errors.ts` file. I tried to be as conservative as possible with my edits and did a lot of research on the best way to implement 'default' properties in `class` declarations in TypeScript. I'm still pretty new to coding in TypeScript so I'm happy to make any corrections or edits if you would prefer things be handled differently.

Some quick notes to summarize things we discussed previously:

- I opted not to expose a `code` property on `TemplateError` instances since I think good error tracing can help identify the problem. 
- Likewise, I removed redundant logging of the `cause` message from `TemplateError` implementations, instead only including a short message with `cause.name` if it's defined. The `TransformError` message only adds context about the compiled JS function so I think it's better left in the stack.

  <details>
    <summary>A `TransformError` now looks like this:</summary>

    ```console
    error: Uncaught (in promise) TemplateError: Error in template test.vto:1:1

    {{ foo 'alpha', 'beta', 'gamma' }}

    (via TransformError)

              throw new TemplateError(path, source, cause.position, cause);
                    ^
        at Environment.compile (file:///Users/noel/Developer/projects/external/vento/src/environment.ts:144:17)
        at Environment.load (file:///Users/noel/Developer/projects/external/vento/src/environment.ts:208:29)
        at eventLoopTick (ext:core/01_core.js:175:7)
        at async file:///Users/noel/Developer/tests/vento-transformations/run.js:5:18
    Caused by: TransformError: [meriyah] [2:26-2:33]: Expected ')' while parsing compiled template function:

    2 __exports.content += (foo 'alpha', 'beta', 'gamma') ?? "";
                              ^
        at transformTemplateCode (file:///Users/noel/Developer/projects/external/vento/src/transformer.ts:150:11)
        at Environment.compile (file:///Users/noel/Developer/projects/external/vento/src/environment.ts:141:16)
        at Environment.load (file:///Users/noel/Developer/projects/external/vento/src/environment.ts:208:29)
        at eventLoopTick (ext:core/01_core.js:175:7)
        at async file:///Users/noel/Developer/tests/vento-transformations/run.js:5:18
    ```


  </details>
- I added an argument to the Environment `Function` constructor to expose `TemplateError` class to the compiled template. I tried adding it to the Environment class (`new this.error`) but since `TemplateError` is hoisted it seemed cleaner to use it as a global.
- Moved `errorLine` to `errors.ts` and exported it so it can be used elsewhere. Not sure if you want `errors.ts` to be included as a module entrypoint.

Let me know if there's any corrections I can make! Thanks for taking a look.