### PR TITLE
patch TemplateError to remove `cause.name` in `message`

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,10 +14,6 @@ export class TemplateError extends VentoBaseError {
       `Error in template ${path}:${line}:${column}\n\n${code.trim()}\n\n`,
       { cause },
     );
-
-    if (cause) {
-      this.message += `(via ${cause.name})\n`;
-    }
   }
 }
 


### PR DESCRIPTION
Hi—sorry, quick patch here on the error subclass. 

I'd like to revert part of #89 by removing the lines that add `(via ErrorName)` to the error message. I got the idea to include that from Eleventy, but since Eleventy already includes that as a feature, you get error messages that duplicate the `(via ...)` text, like so:

```console
[11ty] Error in template src/vento.vto:1:61
[11ty] 
[11ty] <empty file>
[11ty] 
[11ty] (via TemplateError) (via TemplateError)
```

```console
[11ty] Error in template src/_includes/include.vto:1:1
[11ty] 
[11ty] {{ hello.hello }}
[11ty] 
[11ty] (via TypeError) (via TemplateError)
```

Is it better to leave the error handling (including `cause` chains, and the like) up to the implementation, like Eleventy, Lume, and others?

Sorry for the confusion!