### PR TITLE
Fix property destruct codegen

### DIFF
--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -228,11 +228,13 @@ export function transformTemplateCode(
           break;
 
         case "Property":
-          if (node.shorthand && node.key.type === "Identifier") {
+          // Value is implicitly the same as the key if it's just an
+          // identifier, so we only transform the value (not the key)
+          if (node.shorthand && node.value.type === "Identifier") {
             this.replace({
               type: "Property",
               key: node.key,
-              value: transformIdentifier(node.key),
+              value: transformIdentifier(node.value),
               kind: "init",
               computed: false,
               method: false,

--- a/test/js.test.ts
+++ b/test/js.test.ts
@@ -79,4 +79,12 @@ Deno.test("> tag", async () => {
     `,
     expected: "Hello s",
   });
+
+  await test({
+    template: `
+    {{> const { a = 2 } = {}; }}
+    {{ JSON.stringify(a) }}
+    `,
+    expected: "2",
+  });
 });


### PR DESCRIPTION
Fixes #92, which incorrectly transformed the key instead of the property value. Also added an extra JS test to cover the other case.