### PR TITLE
Add bare flag to config

### DIFF
--- a/bare.ts
+++ b/bare.ts
@@ -1,0 +1,24 @@
+import { Environment } from "./src/environment.ts";
+import { FileLoader, Loader } from "./src/loader.ts";
+
+export interface Options {
+  includes?: string | Loader;
+  autoDataVarname?: boolean;
+  dataVarname?: string;
+  autoescape?: boolean;
+}
+
+export default function (options: Options = {}): Environment {
+  const loader = typeof options.includes === "object"
+    ? options.includes
+    : new FileLoader(options.includes || Deno.cwd());
+
+  const env = new Environment({
+    loader,
+    dataVarname: options.dataVarname || "it",
+    autoescape: options.autoescape ?? false,
+    autoDataVarname: options.autoDataVarname ?? true,
+  });
+
+  return env;
+}

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,5 @@
+import create, {Options as BareOptions} from "./bare.ts";
 import { Environment } from "./src/environment.ts";
-import { FileLoader, Loader } from "./src/loader.ts";
 import ifTag from "./plugins/if.ts";
 import forTag from "./plugins/for.ts";
 import includeTag from "./plugins/include.ts";
@@ -14,44 +14,31 @@ import escape from "./plugins/escape.ts";
 import unescape from "./plugins/unescape.ts";
 import trim from "./plugins/trim.ts";
 
-export interface Options {
-  includes?: string | Loader;
+export interface Options extends BareOptions {
   /** @deprecated Use autoDataVarname */
   useWith?: boolean;
-  autoDataVarname?: boolean;
-  dataVarname?: string;
-  autoescape?: boolean;
-  bare?: boolean;
 }
 
 export default function (options: Options = {}): Environment {
-  const loader = typeof options.includes === "object"
-    ? options.includes
-    : new FileLoader(options.includes || Deno.cwd());
-
-  const env = new Environment({
-    loader,
-    dataVarname: options.dataVarname || "it",
-    autoescape: options.autoescape ?? false,
+  const env = create({
+    ...options,
     autoDataVarname: options.autoDataVarname ?? options.useWith ?? true,
   });
 
-  if (!options.bare) {
-    // Register basic plugins
-    env.use(ifTag());
-    env.use(forTag());
-    env.use(jsTag());
-    env.use(includeTag());
-    env.use(setTag());
-    env.use(layoutTag());
-    env.use(functionTag());
-    env.use(importTag());
-    env.use(exportTag());
-    env.use(echoTag());
-    env.use(escape());
-    env.use(unescape());
-    env.use(trim());
-  }
+  // Register basic plugins
+  env.use(ifTag());
+  env.use(forTag());
+  env.use(jsTag());
+  env.use(includeTag());
+  env.use(setTag());
+  env.use(layoutTag());
+  env.use(functionTag());
+  env.use(importTag());
+  env.use(exportTag());
+  env.use(echoTag());
+  env.use(escape());
+  env.use(unescape());
+  env.use(trim());
 
   return env;
 }

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import create, {Options as BareOptions} from "./bare.ts";
+import create, { Options as BareOptions } from "./bare.ts";
 import { Environment } from "./src/environment.ts";
 import ifTag from "./plugins/if.ts";
 import forTag from "./plugins/for.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -21,6 +21,7 @@ export interface Options {
   autoDataVarname?: boolean;
   dataVarname?: string;
   autoescape?: boolean;
+  bare?: boolean;
 }
 
 export default function (options: Options = {}): Environment {
@@ -35,20 +36,22 @@ export default function (options: Options = {}): Environment {
     autoDataVarname: options.autoDataVarname ?? options.useWith ?? true,
   });
 
-  // Register basic plugins
-  env.use(ifTag());
-  env.use(forTag());
-  env.use(jsTag());
-  env.use(includeTag());
-  env.use(setTag());
-  env.use(layoutTag());
-  env.use(functionTag());
-  env.use(importTag());
-  env.use(exportTag());
-  env.use(echoTag());
-  env.use(escape());
-  env.use(unescape());
-  env.use(trim());
+  if (!options.bare) {
+    // Register basic plugins
+    env.use(ifTag());
+    env.use(forTag());
+    env.use(jsTag());
+    env.use(includeTag());
+    env.use(setTag());
+    env.use(layoutTag());
+    env.use(functionTag());
+    env.use(importTag());
+    env.use(exportTag());
+    env.use(echoTag());
+    env.use(escape());
+    env.use(unescape());
+    env.use(trim());
+  }
 
   return env;
 }


### PR DESCRIPTION
Initially, I considered creating a separate `mini.ts`, but it would essentially be a full copy of `mod.ts` without plugin registration. I’d prefer to avoid duplicating the Vento creation logic.  

Then, I thought about adding `plugins: []` to the config and filling it with the default plugins by default, but it’s unclear how to use both all default plugins and a custom one at the same time.  

In the end, the `bare` flag seems like the simplest way to solve this problem. Changing the API might not be ideal, but all of these approaches modify the API in some way.



resolve #98