### PR TITLE
Proof of concept: variables without meriyah

### DIFF
--- a/plugins/set.ts
+++ b/plugins/set.ts
@@ -31,7 +31,7 @@ function setTag(
     const [, variable, value] = match;
     const val = env.compileFilters(tokens, value);
 
-    return `${dataVarname}["${variable}"] = ${val};`;
+    return `${variable} = ${val};`;
   }
 
   // Value is captured (eg: {{ set foo }}bar{{ /set }})


### PR DESCRIPTION
This PR is not for merge.

This shows off a method of avoiding parsing JavaScript to alter the accessing of variables. Instead of altering the code to account for how the variables are passed into the template function, the template function is defined in a way that the variables can be accessed as-is.

About two-thirds of the tests pass; mostly this seems to be related to includes and filters, but it seems these are solvable problems (just didn't think it needed to solve them for the sake of showing the proof-of-concept).

@oscarotero would love to hear your thoughts on this approach, and if it's something you're interesting in pursuing.