### PR TITLE
Another POC of doing variables without Meriyah

### DIFF
--- a/bare.ts
+++ b/bare.ts
@@ -18,6 +18,7 @@ export default function (options: Options = {}): Environment {
     dataVarname: options.dataVarname || "it",
     autoescape: options.autoescape ?? false,
     autoDataVarname: options.autoDataVarname ?? true,
+    strict: options.strict ?? false,
   });
 
   return env;

--- a/plugins/set.ts
+++ b/plugins/set.ts
@@ -31,12 +31,17 @@ function setTag(
     const [, variable, value] = match;
     const val = env.compileFilters(tokens, value);
 
+    if(env.options.strict){
+      return `var ${variable} = ${dataVarname}["${variable}"] = ${val};`
+    }
+
     return `${dataVarname}["${variable}"] = ${val};`;
   }
 
   // Value is captured (eg: {{ set foo }}bar{{ /set }})
   const compiled: string[] = [];
-  const subvarName = `${dataVarname}["${expression.trim()}"]`;
+  const variable = expression.trim()
+  const subvarName = `${dataVarname}["${variable}"]`;
   const compiledFilters = env.compileFilters(tokens, subvarName);
 
   compiled.push(`${subvarName} = "";`);
@@ -48,5 +53,8 @@ function setTag(
 
   tokens.shift();
   compiled.push(`${subvarName} = ${compiledFilters};`);
+  if(env.options.strict){
+    compiled.push(`var ${variable} = ${subvarName};`)
+  }
   return compiled.join("\n");
 }


### PR DESCRIPTION
This time, no code analysis needed! In a nutshell, this means we can keep the naive parsing (which is fast) and then just... _not_ parse the resulting JavaScript function.

The way I've approached this is by creating some sort of "strict mode" (related: https://github.com/ventojs/vento/issues/101). The variables are not detected from the code itself, but rather by what's passed in the `it` object. Since this can change, the template function _can_ re-compile itself if it finds new keys have been added to the `it` object, but presumably this doesn't happen very often for people opting in to a strict mode.

Only 8 of the tests are failing, I think most of which I reckon _should_ fail in a "strict" mode, so I think this is quite a promising strategy.
