### PR TITLE
Genericize tokenzation of echo tags

### DIFF
--- a/plugins/echo.ts
+++ b/plugins/echo.ts
@@ -25,11 +25,11 @@ function echoTag(
   }
 
   // Captured echo, e.g. {{ echo |> toUpperCase }} foo {{ /echo }}
-  const compiled = [`let _tmp = "";`];
-  const filters = env.compileFilters(tokens, "_tmp");
-  compiled.push(...env.compileTokens(tokens, "_tmp", ["/echo"]));
-  if (filters != "_tmp") {
-    compiled.push(`_tmp = ${filters}`);
+  const compiled = [`let __tmp = "";`];
+  const filters = env.compileFilters(tokens, "__tmp");
+  compiled.push(...env.compileTokens(tokens, "__tmp", ["/echo"]));
+  if (filters != "__tmp") {
+    compiled.push(`__tmp = ${filters}`);
   }
 
   const closeToken = tokens.shift();
@@ -39,6 +39,6 @@ function echoTag(
 
   return `{
     ${compiled.join("\n")}
-    ${output} += _tmp;
+    ${output} += __tmp;
   }`;
 }

--- a/plugins/echo.ts
+++ b/plugins/echo.ts
@@ -13,12 +13,32 @@ function echoTag(
   output: string,
   tokens: Token[],
 ): string | undefined {
-  if (!code.startsWith("echo ")) {
+  if (!/^echo\b/.test(code)) {
     return;
   }
 
-  const value = code.replace(/^echo\s+/, "");
-  const val = env.compileFilters(tokens, value, env.options.autoescape);
+  const inline = code.slice(4).trim();
+  // Inline value, e.g. {{ echo "foo" |> toUpperCase() }}
+  if (inline) {
+    const compiled = env.compileFilters(tokens, inline, env.options.autoescape);
+    return `${output} += ${compiled};`;
+  }
 
-  return `${output} += ${val};`;
+  // Captured echo, e.g. {{ echo |> toUpperCase }} foo {{ /echo }}
+  const compiled = [`let _tmp = "";`];
+  const filters = env.compileFilters(tokens, "_tmp");
+  compiled.push(...env.compileTokens(tokens, "_tmp", ["/echo"]));
+  if (filters != "_tmp") {
+    compiled.push(`_tmp = ${filters}`);
+  }
+
+  const closeToken = tokens.shift();
+  if (!closeToken || closeToken[0] != "tag" || closeToken[1] != "/echo") {
+    throw new Error("Unclosed echo tag");
+  }
+
+  return `{
+    ${compiled.join("\n")}
+    ${output} += _tmp;
+  }`;
 }

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -187,13 +187,7 @@ export class Environment {
   }
 
   tokenize(source: string, path?: string): Token[] {
-    const result = tokenize(source);
-    let { tokens } = result;
-    const { position, error } = result;
-
-    if (error) {
-      throw new TemplateError(path, source, position, error);
-    }
+    let tokens = tokenize(source);
 
     for (const tokenPreprocessor of this.tokenPreprocessors) {
       const result = tokenPreprocessor(this, tokens, path);

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -3,98 +3,88 @@ import analyze from "./js.ts";
 export type TokenType = "string" | "tag" | "filter" | "comment";
 export type Token = [TokenType, string, number?];
 
-export interface TokenizeResult {
-  tokens: Token[];
-  position: number;
-  error: Error | undefined;
-}
-
-export default function tokenize(source: string): TokenizeResult {
+export default function tokenize(source: string): Token[] {
   const tokens: Token[] = [];
   let type: TokenType = "string";
   let position = 0;
 
-  try {
-    while (source.length > 0) {
-      if (type === "string") {
-        const index = source.indexOf("{{");
-        const code = index === -1 ? source : source.slice(0, index);
+  while (source.length > 0) {
+    if (type === "string") {
+      const index = source.indexOf("{{");
+      const code = index === -1 ? source : source.slice(0, index);
 
-        tokens.push([type, code, position]);
+      tokens.push([type, code, position]);
 
-        if (index === -1) {
-          break;
-        }
-
-        position += index;
-        source = source.slice(index);
-        type = source.startsWith("{{#") ? "comment" : "tag";
-        continue;
+      if (index === -1) {
+        break;
       }
 
-      if (type === "comment") {
-        source = source.slice(3);
-        const index = source.indexOf("#}}");
-        const comment = index === -1 ? source : source.slice(0, index);
-        tokens.push([type, comment, position]);
-
-        if (index === -1) {
-          break;
-        }
-
-        position += index + 3;
-        source = source.slice(index + 3);
-        type = "string";
-        continue;
-      }
-
-      if (type === "tag") {
-        const indexes = parseTag(source);
-        const lastIndex = indexes.length - 1;
-        let tag: Token | undefined;
-
-        indexes.reduce((prev, curr, index) => {
-          const code = source.slice(prev, curr - 2);
-
-          // Tag
-          if (index === 1) {
-            tag = [type, code, position];
-            tokens.push(tag);
-            return curr;
-          }
-
-          // Filters
-          tokens.push(["filter", code]);
-          return curr;
-        });
-
-        position += indexes[lastIndex];
-        source = source.slice(indexes[lastIndex]);
-        type = "string";
-
-        // Search the closing echo tag {{ /echo }}
-        if (tag?.[1].match(/^\-?\s*echo\s*\-?$/)) {
-          const end = source.match(/{{\-?\s*\/echo\s*\-?}}/);
-
-          if (!end) {
-            throw new Error("Unclosed echo tag");
-          }
-
-          const rawCode = source.slice(0, end.index);
-          tag[1] = `echo ${JSON.stringify(rawCode)}`;
-          const length = Number(end.index) + end[0].length;
-          source = source.slice(length);
-          position += length;
-        }
-
-        continue;
-      }
+      position += index;
+      source = source.slice(index);
+      type = source.startsWith("{{#") ? "comment" : "tag";
+      continue;
     }
-  } catch (error) {
-    return { tokens, position, error: error as Error | undefined };
-  }
 
-  return { tokens, position, error: undefined };
+    if (type === "comment") {
+      source = source.slice(3);
+      const index = source.indexOf("#}}");
+      const comment = index === -1 ? source : source.slice(0, index);
+      tokens.push([type, comment, position]);
+
+      if (index === -1) {
+        break;
+      }
+
+      position += index + 3;
+      source = source.slice(index + 3);
+      type = "string";
+      continue;
+    }
+
+    if (type === "tag") {
+      const indexes = parseTag(source);
+      const lastIndex = indexes.length - 1;
+      let tag: Token | undefined;
+
+      indexes.reduce((prev, curr, index) => {
+        const code = source.slice(prev, curr - 2);
+
+        // Tag
+        if (index === 1) {
+          tag = [type, code, position];
+          tokens.push(tag);
+          return curr;
+        }
+
+        // Filters
+        tokens.push(["filter", code]);
+        return curr;
+      });
+
+      position += indexes[lastIndex];
+      source = source.slice(indexes[lastIndex]);
+      type = "string";
+
+      // Search the closing echo tag {{ /echo }}
+      if (tag?.[1].match(/^\-?\s*echo\s*\-?$/)) {
+        const end = /{{\-?\s*\/echo\s*\-?}}/.exec(source);
+
+        if (!end) {
+          tokens.push(["string", source, position]);
+          return tokens;
+        }
+
+        tokens.push(["string", source.slice(0, end.index), position]);
+        position += end.index;
+        tokens.push(["tag", end[0].slice(2, -2), position]);
+        position += end[0].length;
+        source = source.slice(end.index + end[0].length);
+      }
+
+      continue;
+    }
+  }
+  return tokens;
 }
 
 /**

--- a/test/echo.test.ts
+++ b/test/echo.test.ts
@@ -70,6 +70,13 @@ Deno.test("Echo tag", async () => {
     },
   });
 
+  await test({
+    template: `
+    Hello {{-echo-}} beautiful {{-/echo-}} world!
+    `,
+    expected: "Hellobeautifulworld!",
+  });
+
   testThrows({
     options: {
       autoDataVarname: false,


### PR DESCRIPTION
The echo tag got some special handling within tokenization. Specifically it was transformed to an inline echo; for example, `{{echo}}foo{{/echo}}` was transformed to `{{echo "foo"}}`. This special handling isn't really needed, creates the perception of unreliable tokenization, and complicates making changes to the tokenization process.

It also created a subtle bug where it overwrote all of the whitespace trimming markers, because the tag was overwritten without explicitly handling their presence. This points to a deeper issue; custom plugins (including the trim plugin) can no longer rely on working together with the echo tag. Working with the `trim` plugin is a special case, since we cannot reliably detect what tags are echo tags within the tokenization process in general. However, plugins that transform tokens to include capture-style echo tags could not work, as the echo plugin only handled inline echo tags.

As a bonus, this simplifies the signature of the internal `tokenize` function, since we throw the "Unclosed echo tag" error within the echo plugin. This makes a bit more sense anyway; the `tokenize` function ideally shouldn't throw even if tags are unclosed (it even allows an unclosed `{{#`).

PS most of the `tokenize` function is the same, it's just dedented since the `try { ... } catch { ... }` has been removed; turn off whitespace diffing to see a better diff.