### PR TITLE
Rework `analyze` function signature

### DIFF
--- a/plugins/for.ts
+++ b/plugins/for.ts
@@ -156,15 +156,9 @@ async function* asyncIterableToEntries(
 }
 
 function getDestructureContent(code: string): [string, string] {
-  let position = -1;
-  const open = code[0];
-  const close = { "[": "]", "{": "}" }[open]!;
-  for (const [index, reason] of topLevel(code, 1)) {
-    if (reason != close) continue;
-    position = index;
-    break;
-  }
-  position++;
+  const generator = topLevel(code, 0);
+  generator.next();
+  const [position] = generator.next().value;
   return [
     code.slice(0, position).trim(),
     code.slice(position).trim(),

--- a/plugins/for.ts
+++ b/plugins/for.ts
@@ -1,4 +1,4 @@
-import { topLevel } from "../src/js.ts";
+import iterateTopLevel from "../src/js.ts";
 import type { Token } from "../src/tokenizer.ts";
 import type { Environment, Plugin } from "../src/environment.ts";
 
@@ -156,11 +156,11 @@ async function* asyncIterableToEntries(
 }
 
 function getDestructureContent(code: string): [string, string] {
-  const generator = topLevel(code, 0);
+  const generator = iterateTopLevel(code, 0);
   generator.next();
   const [position] = generator.next().value;
   return [
-    code.slice(0, position).trim(),
-    code.slice(position).trim(),
+    code.slice(0, position + 1).trim(),
+    code.slice(position + 1).trim(),
   ];
 }

--- a/plugins/for.ts
+++ b/plugins/for.ts
@@ -156,15 +156,17 @@ async function* asyncIterableToEntries(
 }
 
 function getDestructureContent(code: string): [string, string] {
-  let index = 1;
+  let position = -1;
   const open = code[0];
   const close = { "[": "]", "{": "}" }[open]!;
-  do {
-    index = topLevel(code, index);
-  } while (index < code.length && code[index] != close);
-  index++;
+  for (const [index, reason] of topLevel(code, 1)) {
+    if (reason != close) continue;
+    position = index;
+    break;
+  }
+  position++;
   return [
-    code.slice(0, index).trim(),
-    code.slice(index).trim(),
+    code.slice(0, position).trim(),
+    code.slice(position).trim(),
   ];
 }

--- a/plugins/for.ts
+++ b/plugins/for.ts
@@ -158,16 +158,10 @@ async function* asyncIterableToEntries(
 function getDestructureContent(code: string): [string, string] {
   let index = 1;
   const open = code[0];
-  const close = { "[": "]", "{": "}" }[open];
-  if (!close) {
-    throw Error(`Unrecognized destructuring in for loop: ${code}`);
-  }
+  const close = { "[": "]", "{": "}" }[open]!;
   do {
     index = topLevel(code, index);
   } while (index < code.length && code[index] != close);
-  if (index == code.length) {
-    throw Error(`Unclosed destructured loop variable: ${code}`);
-  }
   index++;
   return [
     code.slice(0, index).trim(),

--- a/plugins/for.ts
+++ b/plugins/for.ts
@@ -156,7 +156,7 @@ async function* asyncIterableToEntries(
 }
 
 function getDestructureContent(code: string): [string, string] {
-  const generator = iterateTopLevel(code, 0);
+  const generator = iterateTopLevel(code);
   generator.next();
   const [position] = generator.next().value;
   return [

--- a/plugins/include.ts
+++ b/plugins/include.ts
@@ -1,4 +1,4 @@
-import { topLevel } from "../src/js.ts";
+import iterateTopLevel from "../src/js.ts";
 import type { Token } from "../src/tokenizer.ts";
 import type { Environment, Plugin } from "../src/environment.ts";
 
@@ -25,8 +25,8 @@ function includeTag(
   // includes { data }
   if (tagCode.endsWith("}")) {
     let bracketIndex = -1;
-    for (const [index, reason] of topLevel(tagCode, 0)) {
-      if (reason == "{") bracketIndex = index - 1;
+    for (const [index, reason] of iterateTopLevel(tagCode, 0)) {
+      if (reason == "{") bracketIndex = index;
     }
     if (bracketIndex == -1) {
       throw Error(`Invalid include tag: ${tagCode}`);

--- a/plugins/include.ts
+++ b/plugins/include.ts
@@ -25,7 +25,7 @@ function includeTag(
   // includes { data }
   if (tagCode.endsWith("}")) {
     let bracketIndex = -1;
-    for (const [index, reason] of iterateTopLevel(tagCode, 0)) {
+    for (const [index, reason] of iterateTopLevel(tagCode)) {
       if (reason == "{") bracketIndex = index;
     }
     if (bracketIndex == -1) {

--- a/plugins/include.ts
+++ b/plugins/include.ts
@@ -24,19 +24,15 @@ function includeTag(
 
   // includes { data }
   if (tagCode.endsWith("}")) {
-    const target = tagCode.length - 1;
-    let index = -1;
-    for (const match of tagCode.matchAll(/{/g)) {
-      if (topLevel(tagCode, match.index + 1) == target) {
-        index = match.index;
-        break;
-      }
+    let bracketIndex = -1;
+    for (const [index, reason] of topLevel(tagCode, 0)) {
+      if (reason == "{") bracketIndex = index;
     }
-    if (index == -1) {
+    if (bracketIndex == -1) {
       throw Error(`Invalid include tag: ${tagCode}`);
     }
-    file = tagCode.slice(0, index).trim();
-    data = tagCode.slice(index).trim();
+    file = tagCode.slice(0, bracketIndex).trim();
+    data = tagCode.slice(bracketIndex).trim();
   }
 
   const { dataVarname } = env.options;

--- a/plugins/include.ts
+++ b/plugins/include.ts
@@ -26,7 +26,7 @@ function includeTag(
   if (tagCode.endsWith("}")) {
     let bracketIndex = -1;
     for (const [index, reason] of topLevel(tagCode, 0)) {
-      if (reason == "{") bracketIndex = index;
+      if (reason == "{") bracketIndex = index - 1;
     }
     if (bracketIndex == -1) {
       throw Error(`Invalid include tag: ${tagCode}`);

--- a/src/js.ts
+++ b/src/js.ts
@@ -52,13 +52,13 @@ export function* topLevel(
 
       // Detect end brackets
       case "}": {
-        if (statuses.length === 0) yield [index - 1, "}"];
         switch (statuses[0]) {
           // Close a bracket
           case "bracket":
             statuses.shift();
             break;
         }
+        if (statuses.length === 0) yield [index, "}"];
         break;
       }
 
@@ -134,7 +134,6 @@ export function* topLevel(
       }
 
       case "]": {
-        if (statuses.length === 0) yield [index - 1, "]"];
         switch (statuses[0]) {
           // Close a square bracket in a regex
           case "regex-bracket":
@@ -148,6 +147,7 @@ export function* topLevel(
             statuses.shift();
             break;
         }
+        if (statuses.length === 0) yield [index, "]"];
         break;
       }
 
@@ -208,7 +208,8 @@ export function* topLevel(
 
       case "|": {
         if (statuses.length === 0 && source.charAt(index) === ">") {
-          yield [index - 1, "|>"];
+          index++;
+          yield [index, "|>"];
         }
         break;
       }

--- a/src/js.ts
+++ b/src/js.ts
@@ -15,7 +15,10 @@ type status =
   | "comment"
   | "line-comment";
 
-export function topLevel(source: string, start: number): number {
+export function* topLevel(
+  source: string,
+  start: number,
+): Generator<[number, string]> {
   const length = source.length;
   const statuses: status[] = [];
   let index = start;
@@ -40,6 +43,7 @@ export function topLevel(source: string, start: number): number {
           case undefined:
           case "square-bracket":
           case "bracket":
+            if (statuses.length == 0) yield [index - 1, "{"];
             statuses.unshift("bracket");
             break;
         }
@@ -48,7 +52,7 @@ export function topLevel(source: string, start: number): number {
 
       // Detect end brackets
       case "}": {
-        if (statuses.length === 0) return index - 1;
+        if (statuses.length === 0) yield [index - 1, "}"];
         switch (statuses[0]) {
           // Close a bracket
           case "bracket":
@@ -122,6 +126,7 @@ export function topLevel(source: string, start: number): number {
           case undefined:
           case "square-bracket":
           case "bracket":
+            if (statuses.length == 0) yield [index - 1, "["];
             statuses.unshift("square-bracket");
             break;
         }
@@ -129,7 +134,7 @@ export function topLevel(source: string, start: number): number {
       }
 
       case "]": {
-        if (statuses.length === 0) return index - 1;
+        if (statuses.length === 0) yield [index - 1, "]"];
         switch (statuses[0]) {
           // Close a square bracket in a regex
           case "regex-bracket":
@@ -203,13 +208,13 @@ export function topLevel(source: string, start: number): number {
 
       case "|": {
         if (statuses.length === 0 && source.charAt(index) === ">") {
-          return index - 1;
+          yield [index - 1, "|>"];
         }
         break;
       }
     }
   }
-  return index;
+  return [index, ""];
 }
 
 // Get the previous character in a string ignoring spaces, line breaks and tabs

--- a/src/js.ts
+++ b/src/js.ts
@@ -17,7 +17,7 @@ type status =
 
 export default function* iterateTopLevel(
   source: string,
-  start: number,
+  start: number = 0,
 ): Generator<[number, string]> {
   const length = source.length;
   const statuses: status[] = [];

--- a/src/js.ts
+++ b/src/js.ts
@@ -15,7 +15,7 @@ type status =
   | "comment"
   | "line-comment";
 
-export function* topLevel(
+export default function* iterateTopLevel(
   source: string,
   start: number,
 ): Generator<[number, string]> {
@@ -58,7 +58,7 @@ export function* topLevel(
             statuses.shift();
             break;
         }
-        if (statuses.length === 0) yield [index, "}"];
+        if (statuses.length === 0) yield [index - 1, "}"];
         break;
       }
 
@@ -147,7 +147,7 @@ export function* topLevel(
             statuses.shift();
             break;
         }
-        if (statuses.length === 0) yield [index, "]"];
+        if (statuses.length === 0) yield [index - 1, "]"];
         break;
       }
 
@@ -209,7 +209,7 @@ export function* topLevel(
       case "|": {
         if (statuses.length === 0 && source.charAt(index) === ">") {
           index++;
-          yield [index, "|>"];
+          yield [index - 2, "|>"];
         }
         break;
       }

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -102,18 +102,14 @@ export default function tokenize(source: string): TokenizeResult {
  * For example: {{ tag |> filter1 |> filter2 }} => [2, 9, 20, 31]
  */
 export function parseTag(source: string): number[] {
-  const indexes: number[] = [];
-  let cursor = 0;
-  parsing: do {
-    cursor += 2;
-    indexes.push(cursor);
-    do {
-      cursor = topLevel(source, cursor);
-      if (cursor == source.length) break parsing;
-      if (!source.startsWith("}}", cursor)) continue;
-      indexes.push(cursor + 2);
-      return indexes;
-    } while (!source.startsWith("|>", cursor));
-  } while (cursor < source.length);
+  const indexes = [2];
+  for (const [index, reason] of topLevel(source, 2)) {
+    if (reason == "|>") {
+      indexes.push(index + 2);
+      continue;
+    } else if (!source.startsWith("}}", index)) continue;
+    indexes.push(index + 2);
+    return indexes;
+  }
   throw new Error("Unclosed tag");
 }

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,4 +1,4 @@
-import { topLevel } from "./js.ts";
+import iterateTopLevel from "./js.ts";
 
 export type TokenType = "string" | "tag" | "filter" | "comment";
 export type Token = [TokenType, string, number?];
@@ -103,12 +103,12 @@ export default function tokenize(source: string): TokenizeResult {
  */
 export function parseTag(source: string): number[] {
   const indexes = [2];
-  for (const [index, reason] of topLevel(source, 2)) {
+  for (const [index, reason] of iterateTopLevel(source, 2)) {
     if (reason == "|>") {
-      indexes.push(index);
+      indexes.push(index + 2);
       continue;
-    } else if (!source.startsWith("}}", index - 1)) continue;
-    indexes.push(index + 1);
+    } else if (!source.startsWith("}}", index)) continue;
+    indexes.push(index + 2);
     return indexes;
   }
   throw new Error("Unclosed tag");

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -105,10 +105,10 @@ export function parseTag(source: string): number[] {
   const indexes = [2];
   for (const [index, reason] of topLevel(source, 2)) {
     if (reason == "|>") {
-      indexes.push(index + 2);
+      indexes.push(index);
       continue;
-    } else if (!source.startsWith("}}", index)) continue;
-    indexes.push(index + 2);
+    } else if (!source.startsWith("}}", index - 1)) continue;
+    indexes.push(index + 1);
     return indexes;
   }
   throw new Error("Unclosed tag");

--- a/test/include.test.ts
+++ b/test/include.test.ts
@@ -269,3 +269,19 @@ Deno.test("Include tag with object shorthand syntax", async () => {
     },
   });
 });
+
+Deno.test("Include tag with semi-ambiguous JS objects", async () => {
+  await test({
+    template: `
+    {{> const resolve = ({path}) => path; }}
+    {{ include resolve({ path: "/my-file.tmpl" }) { name } }}
+    `,
+    expected: "Hello Vento",
+    includes: {
+      "/my-file.tmpl": "Hello {{ name }}",
+    },
+    data: {
+      name: "Vento",
+    },
+  });
+});


### PR DESCRIPTION
The original `analyze` function takes a `visitor` argument, and this is a bit awkward to work with in isolation. To do performance optimizations, it is more ergonomic for this function to be lower level, taking only primitive arguments, reducing the entanglement with other parts of the codebase.

As such, I've reworked it to a `topLevel` function that reads a string of JavaScript until it encounters a character that "breaks" out of the top-level context; specifically this happens when it encounters a top-level `}`, `]`, or `|>`. The algorithm remains mostly the same, since conceptually the `analyze` function and `topLevel` function are doing very similar things.

The "include" tag here is a bit of an outlier. Its syntax is actually rather complex to get right, e.g. `include resolve({path: 'foo.tmpl'}) { bar: 'baz' })` is difficult to parse (both with `analyze` as well as `topLevel`). In this rework I've assumed that the object passed as data is passed literally, i.e. starts with `{` and ends with a matching `}`. I think that's a reasonable requirement to avoid the ambiguity. I've added a test here that passes on this branch but would fail on `main`.