### PR TITLE
Rework analyze to generator

### DIFF
--- a/plugins/for.ts
+++ b/plugins/for.ts
@@ -156,15 +156,17 @@ async function* asyncIterableToEntries(
 }
 
 function getDestructureContent(code: string): [string, string] {
-  let index = 1;
+  let position = -1;
   const open = code[0];
   const close = { "[": "]", "{": "}" }[open]!;
-  do {
-    index = topLevel(code, index);
-  } while (index < code.length && code[index] != close);
-  index++;
+  for (const [index, reason] of topLevel(code, 1)) {
+    if (reason != close) continue;
+    position = index;
+    break;
+  }
+  position++;
   return [
-    code.slice(0, index).trim(),
-    code.slice(index).trim(),
+    code.slice(0, position).trim(),
+    code.slice(position).trim(),
   ];
 }

--- a/plugins/for.ts
+++ b/plugins/for.ts
@@ -158,16 +158,10 @@ async function* asyncIterableToEntries(
 function getDestructureContent(code: string): [string, string] {
   let index = 1;
   const open = code[0];
-  const close = { "[": "]", "{": "}" }[open];
-  if (!close) {
-    throw Error(`Unrecognized destructuring in for loop: ${code}`);
-  }
+  const close = { "[": "]", "{": "}" }[open]!;
   do {
     index = topLevel(code, index);
   } while (index < code.length && code[index] != close);
-  if (index == code.length) {
-    throw Error(`Unclosed destructured loop variable: ${code}`);
-  }
   index++;
   return [
     code.slice(0, index).trim(),

--- a/plugins/include.ts
+++ b/plugins/include.ts
@@ -24,19 +24,15 @@ function includeTag(
 
   // includes { data }
   if (tagCode.endsWith("}")) {
-    const target = tagCode.length - 1;
-    let index = -1;
-    for (const match of tagCode.matchAll(/{/g)) {
-      if (topLevel(tagCode, match.index + 1) == target) {
-        index = match.index;
-        break;
-      }
+    let bracketIndex = -1;
+    for (const [index, reason] of topLevel(tagCode, 0)) {
+      if (reason == "{") bracketIndex = index;
     }
-    if (index == -1) {
+    if (bracketIndex == -1) {
       throw Error(`Invalid include tag: ${tagCode}`);
     }
-    file = tagCode.slice(0, index).trim();
-    data = tagCode.slice(index).trim();
+    file = tagCode.slice(0, bracketIndex).trim();
+    data = tagCode.slice(bracketIndex).trim();
   }
 
   const { dataVarname } = env.options;

--- a/src/js.ts
+++ b/src/js.ts
@@ -15,7 +15,10 @@ type status =
   | "comment"
   | "line-comment";
 
-export function topLevel(source: string, start: number): number {
+export function* topLevel(
+  source: string,
+  start: number,
+): Generator<[number, string]> {
   const length = source.length;
   const statuses: status[] = [];
   let index = start;
@@ -40,6 +43,7 @@ export function topLevel(source: string, start: number): number {
           case undefined:
           case "square-bracket":
           case "bracket":
+            if (statuses.length == 0) yield [index - 1, "{"];
             statuses.unshift("bracket");
             break;
         }
@@ -48,7 +52,7 @@ export function topLevel(source: string, start: number): number {
 
       // Detect end brackets
       case "}": {
-        if (statuses.length === 0) return index - 1;
+        if (statuses.length === 0) yield [index - 1, "}"];
         switch (statuses[0]) {
           // Close a bracket
           case "bracket":
@@ -122,6 +126,7 @@ export function topLevel(source: string, start: number): number {
           case undefined:
           case "square-bracket":
           case "bracket":
+            if (statuses.length == 0) yield [index - 1, "["];
             statuses.unshift("square-bracket");
             break;
         }
@@ -129,7 +134,7 @@ export function topLevel(source: string, start: number): number {
       }
 
       case "]": {
-        if (statuses.length === 0) return index - 1;
+        if (statuses.length === 0) yield [index - 1, "]"];
         switch (statuses[0]) {
           // Close a square bracket in a regex
           case "regex-bracket":
@@ -203,13 +208,13 @@ export function topLevel(source: string, start: number): number {
 
       case "|": {
         if (statuses.length === 0 && source.charAt(index) === ">") {
-          return index - 1;
+          yield [index - 1, "|>"];
         }
         break;
       }
     }
   }
-  return index;
+  return [index, ""];
 }
 
 // Get the previous character in a string ignoring spaces, line breaks and tabs

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -102,18 +102,14 @@ export default function tokenize(source: string): TokenizeResult {
  * For example: {{ tag |> filter1 |> filter2 }} => [2, 9, 20, 31]
  */
 export function parseTag(source: string): number[] {
-  const indexes: number[] = [];
-  let cursor = 0;
-  parsing: do {
-    cursor += 2;
-    indexes.push(cursor);
-    do {
-      cursor = topLevel(source, cursor);
-      if (cursor == source.length) break parsing;
-      if (!source.startsWith("}}", cursor)) continue;
-      indexes.push(cursor + 2);
-      return indexes;
-    } while (!source.startsWith("|>", cursor));
-  } while (cursor < source.length);
+  const indexes = [2];
+  for (const [index, reason] of topLevel(source, 2)) {
+    if (reason == "|>") {
+      indexes.push(index + 2);
+      continue;
+    } else if (!source.startsWith("}}", index)) continue;
+    indexes.push(index + 2);
+    return indexes;
+  }
   throw new Error("Unclosed tag");
 }

--- a/test/include.test.ts
+++ b/test/include.test.ts
@@ -269,3 +269,19 @@ Deno.test("Include tag with object shorthand syntax", async () => {
     },
   });
 });
+
+Deno.test("Include tag with semi-ambiguous JS objects", async () => {
+  await test({
+    template: `
+    {{> const resolve = ({path}) => path; }}
+    {{ include resolve({ path: "/my-file.tmpl" }) { name } }}
+    `,
+    expected: "Hello Vento",
+    includes: {
+      "/my-file.tmpl": "Hello {{ name }}",
+    },
+    data: {
+      name: "Vento",
+    },
+  });
+});


### PR DESCRIPTION
Builds further on the `rework-analyze-function-signature` branch (see https://github.com/ventojs/vento/pull/121). Effectively the same logic, just with a slightly different interface. Opening a separate PR so it's easier to compare the two methods.

One thing to consider is that this method does burden the JS engine with garbage collecting the generator if it is broken out of earlier (or just in general, I suppose).
