### PR TITLE
Remove `jsr:@std/html` dependency

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,3 @@
-export * as html from "jsr:@std/html@1.0.3";
-
 export * as astring from "jsr:@davidbonnet/astring@1.8.6";
 export * as meriyah from "npm:meriyah@6.0.5";
 export * as walker from "npm:estree-walker@3.0.3";

--- a/plugins/escape.ts
+++ b/plugins/escape.ts
@@ -1,10 +1,19 @@
-import { html } from "../deps.ts";
 import type { Environment, Plugin } from "../src/environment.ts";
+
+const UNSAFE = /['"&<>]/g;
+const escapeMap: Record<string, string> = {
+  "'": "&apos;",
+  '"': "&quot;",
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+};
 
 export default function (): Plugin {
   return (env: Environment) => {
-    // deno-lint-ignore no-explicit-any
-    env.filters.escape = (value: any) =>
-      value ? html.escape(value.toString()) : "";
+    env.filters.escape = (value: unknown) => {
+      if (!value) return "";
+      return value.toString().replace(UNSAFE, (match) => escapeMap[match]);
+    };
   };
 }

--- a/plugins/unescape.ts
+++ b/plugins/unescape.ts
@@ -1,10 +1,27 @@
-import { html } from "../deps.ts";
 import type { Environment, Plugin } from "../src/environment.ts";
+
+const NAMED_ENTITIES = /&(apos|quot|amp|lt|gt);/g;
+const CHAR_REF = /&#(x[0-9A-F]{1,6}|[0-9]{1,7});/gi;
+
+const entities: Record<string, string> = {
+  apos: "'",
+  quot: '"',
+  amp: "&",
+  lt: "<",
+  gt: ">",
+};
 
 export default function (): Plugin {
   return (env: Environment) => {
-    // deno-lint-ignore no-explicit-any
-    env.filters.unescape = (value: any) =>
-      value ? html.unescape(value.toString()) : "";
+    env.filters.unescape = (value: unknown) => {
+      if (!value) return "";
+      return value.toString().replace(NAMED_ENTITIES, (_, name) => {
+        return entities[name];
+      }).replace(CHAR_REF, (full, number) => {
+        const parsed = Number(`0${number}`);
+        if (parsed > 0x10FFFF) return full;
+        return String.fromCodePoint(parsed);
+      });
+    };
   };
 }

--- a/test/unescape.test.ts
+++ b/test/unescape.test.ts
@@ -7,6 +7,12 @@ Deno.test("Unescape filter", async () => {
     `,
     expected: "<h1>Hello world</h1>",
   });
+  await test({
+    template: `
+    {{ "&#x3C;h1&#X03e;Hello world&#60;/h1&#062;" |> unescape }}
+    `,
+    expected: "<h1>Hello world</h1>",
+  });
   testSync({
     template: `
     {{ "&lt;h1&gt;Hello world&lt;/h1&gt;" |> unescape }}


### PR DESCRIPTION
This dependency is relatively large for what it does (>3kB), since it includes a comprehensive list of named HTML entities that Vento doesn't end up using. Instead, we can handle the logic in the "escape" and "unescape" plugins manually.