### PR TITLE
Update Neovim documentation

### DIFF
--- a/docs/3.editor-integrations.md
+++ b/docs/3.editor-integrations.md
@@ -21,17 +21,7 @@ There's a [Vento plugin for Sublime Text](https://packagecontrol.io/packages/Ven
 Vento syntax highlighting is available for Neovim through
 [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter).
 
-To use it, add the "vento" filetype
-
-```lua
-vim.filetype.add({
-  extension = {
-    vto = "vento",
-  },
-});
-```
-
-And install the "vento" parser with `TSInstall`, or add it to the
+To use it, install the "vento" parser with `TSInstall`, or add it to the
 `ensure_installed` list in the `setup` function.
 
 It's also recommended to install "javascript" and "html" parsers to get better


### PR DESCRIPTION
Removed the instructions that add a new filetype. Newer versions of nvim (and vim) have the Vento filetype built-in.