### PR TITLE
Simplify `SafeString` implementation

### DIFF
--- a/core/environment.ts
+++ b/core/environment.ts
@@ -368,17 +368,4 @@ function checkAsync(fn: () => unknown): boolean {
   return fn.constructor?.name === "AsyncFunction";
 }
 
-export class SafeString {
-  #value: string;
-  constructor(value: string) {
-    this.#value = value;
-  }
-
-  toString() {
-    return this.#value;
-  }
-
-  [Symbol.toStringTag]() {
-    return this.toString();
-  }
-}
+export class SafeString extends String {}


### PR DESCRIPTION
Just noticed your solution to the escaping issue the other day - I think this bit could be simplified. We're essentially just recreating methods that already exist on `String`, so we can reuse those instead.

Theoretically we could even use _String_ directly instead of _SafeString_, but I think that would make things needlessly confusing and prevent us from adding methods to `SafeString` later on.