### PR TITLE
Faster escape filter (for v2)

### DIFF
--- a/bench/setup.ts
+++ b/bench/setup.ts
@@ -51,6 +51,15 @@ const initializers = {
     };
   },
 
+  async VentoAutoescape(): Promise<Renderer> {
+    const env = vento({ autoDataVarname: true, autoescape: true });
+    const render = await env.load(dir + "tmp.vto");
+    return async (data: Record<string, unknown>) => {
+      const { content } = await render(data);
+      return content;
+    };
+  },
+
   Nunjucks(): Renderer {
     const loader = new nunjucks.FileSystemLoader(Deno.cwd());
     const env = new nunjucks.Environment(loader);

--- a/plugins/escape.ts
+++ b/plugins/escape.ts
@@ -1,21 +1,47 @@
 import { SafeString } from "../core/environment.ts";
 import type { Environment, Plugin } from "../core/environment.ts";
 
-const UNSAFE = /['"&<>]/g;
-const escapeMap: Record<string, string> = {
-  "'": "&apos;",
-  '"': "&quot;",
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-};
+const UNSAFE = /[<>"&']/;
 
 export default function (): Plugin {
   return (env: Environment) => {
-    env.filters.escape = (value: unknown) => {
-      if (value instanceof SafeString) return value.toString();
+    env.filters.escape = (value: any): string => {
       if (!value) return "";
-      return value.toString().replace(UNSAFE, (match) => escapeMap[match]);
+      if (value instanceof SafeString) return value.toString();
+
+      const str = value.toString();
+
+      const match = UNSAFE.exec(str);
+
+      if (match === null) {
+        return str;
+      }
+
+      let html = '';
+
+      for (let i = match.index; i < str.length; i++) {
+        switch (str.charCodeAt(i)) {
+          case 34: // "
+            html += '&quot;';
+          break;
+          case 39: // '
+            html += '&apos;';
+          break;
+          case 38: // &
+            html += '&amp;';
+          break;
+          case 60: // <
+            html += '&lt;';
+          break;
+          case 62: // >
+            html += '&gt;';
+          break;
+          default:
+            html += str[i];
+        }
+      }
+
+      return html;
     };
   };
 }


### PR DESCRIPTION
This is for the v2 branch to avoid some conficts.

I noticed the benchmarks for Vento were with autoescape disabled, whereas most of the other template engines have it enabled by default. I found the performance of the escape to be pretty slow compared to PugJS (the only other fast templating engine) in particular, so this change fixes the performance.

Before:
```
benchmark         time/iter (avg)        iter/s      (min … max)           p75      p99     p995
----------------- ----------------------------- --------------------- --------------------------
Vento                    349.7 ns     2,860,000 (333.6 ns … 431.9 ns) 353.7 ns 414.4 ns 431.9 ns
VentoAutoescape            1.1 µs       895,800 (  1.1 µs …   1.3 µs)   1.1 µs   1.3 µs   1.3 µs
Pug                      677.4 ns     1,476,000 (665.0 ns … 746.1 ns) 676.5 ns 746.1 ns 746.1 ns
```

After:
```
benchmark         time/iter (avg)        iter/s      (min … max)           p75      p99     p995
----------------- ----------------------------- --------------------- --------------------------
Vento                    344.5 ns     2,902,000 (327.8 ns … 474.5 ns) 355.2 ns 408.5 ns 474.5 ns
VentoAutoescape          618.0 ns     1,618,000 (598.5 ns … 763.7 ns) 637.5 ns 763.7 ns 763.7 ns
Pug                      678.0 ns     1,475,000 (669.1 ns … 735.1 ns) 677.8 ns 735.1 ns 735.1 ns
```