### PR TITLE
Show off selling points on homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@ logo: /favicon.svg
 # 🌬 Vento
 
 Vento is the [Galician](https://en.wikipedia.org/wiki/Galician_language) word
-for _wind_ but also a new JavaScript-based template engine. It's inspired by other
-engines, such as [Nunjucks](https://mozilla.github.io/nunjucks/),
+for _wind_ but also a new JavaScript-based template engine. It's inspired by
+other engines, such as [Nunjucks](https://mozilla.github.io/nunjucks/),
 [Liquid](https://liquidjs.com/), [Eta](https://eta.js.org/), and
 [Mustache](https://mustache.github.io/).
 
@@ -17,10 +17,24 @@ drawbacks and none of them meets all my requirements, so I've created Vento.
 
 Some of Vento's main selling points are:
 
-- All logic is done in JavaScript; there's no need to learn many engine-specific APIs. Compared to engines like Liquid or Nunjucks that restrict authors to their own flow control syntax, larger blocks of logic become a breeze to write in Vento. Additionally, there's much less of a need to learn language-specific features; want to uppercase a string? Use JavaScript's `toUpperCase()` method; no need to look up whether it was `| upper` or `| upcase`.
-- Vento's JavaScript embedding is robust and handles many edge cases correctly. Other JavaScript-based templating languages have various degrees of tolerance for syntax conflicting with delimiters; for example, `<%= '%>' %>` throws an error in EJS, but Vento handles the equivalent, `{{ '}}' }}`, perfectly fine.
-- Vento is async-friendly. Your templates are directly compiled into JavaScript functions, and therefore support asynchronicity out-of-the-box.
-- Vento's tag syntax is more developer-friendly; it reduces the cognitive load by using `{{ … }}` for both tags and interpolation. Additionally, closing tags hit the sweet spot for being short but readable; instead of the longer `{% endfor %}` or more cryptic `<% } %>`, it uses a compact but expressive `{{ /for }}`.
+- All logic is done in JavaScript; there's no need to learn many engine-specific
+  APIs. Compared to engines like Liquid or Nunjucks that restrict authors to
+  their own flow control syntax, larger blocks of logic become a breeze to write
+  in Vento. Additionally, there's much less of a need to learn language-specific
+  features; want to uppercase a string? Use JavaScript's `toUpperCase()` method;
+  no need to look up whether it was `| upper` or `| upcase`.
+- Vento's JavaScript embedding combines a robust compiler with great
+  performance. Unlike many other JavaScript-based templating languages, Vento
+  uses an elaborate delimiter-matching algorithm to handle the vast majority of
+  embedded JavaScript correctly (for example, `{{ '}}' }}`), while retaining its
+  fast compilation speeds and even faster render speeds.
+- Vento is async-friendly. Your templates are directly compiled into JavaScript
+  functions, and therefore support asynchronicity out-of-the-box.
+- Vento's tag syntax is more developer-friendly; it reduces the cognitive load
+  by using `{{ … }}` for both tags and interpolation. Additionally, closing tags
+  hit the sweet spot for being short but readable; instead of the longer
+  `{% endfor %}` or more cryptic `<% } %>`, it uses a compact but expressive
+  `{{ /for }}`.
 
 ### Nunjucks
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ logo: /favicon.svg
 # 🌬 Vento
 
 Vento is the [Galician](https://en.wikipedia.org/wiki/Galician_language) word
-for _wind_ but also a new template engine for Deno and Node. It's inspired by other
+for _wind_ but also a new JavaScript-based template engine. It's inspired by other
 engines, such as [Nunjucks](https://mozilla.github.io/nunjucks/),
 [Liquid](https://liquidjs.com/), [Eta](https://eta.js.org/), and
 [Mustache](https://mustache.github.io/).
@@ -14,6 +14,13 @@ engines, such as [Nunjucks](https://mozilla.github.io/nunjucks/),
 
 All these template engines mentioned above are great but they also have some
 drawbacks and none of them meets all my requirements, so I've created Vento.
+
+Some of Vento's main selling points are:
+
+- All logic is done in JavaScript; there's no need to learn many engine-specific APIs. Compared to engines like Liquid or Nunjucks that restrict authors to their own flow control syntax, larger blocks of logic become a breeze to write in Vento. Additionally, there's much less of a need to learn language-specific features; want to uppercase a string? Use JavaScript's `toUpperCase()` method; no need to look up whether it was `| upper` or `| upcase`.
+- Vento's JavaScript embedding is robust and handles many edge cases correctly. Other JavaScript-based templating languages have various degrees of tolerance for syntax conflicting with delimiters; for example, `<%= '%>' %>` throws an error in EJS, but Vento handles the equivalent, `{{ '}}' }}`, perfectly fine.
+- Vento is async-friendly. Your templates are directly compiled into JavaScript functions, and therefore support asynchronicity out-of-the-box.
+- Vento's tag syntax is more developer-friendly; it reduces the cognitive load by using `{{ … }}` for both tags and interpolation. Additionally, closing tags hit the sweet spot for being short but readable; instead of the longer `{% endfor %}` or more cryptic `<% } %>`, it uses a compact but expressive `{{ /for }}`.
 
 ### Nunjucks
 


### PR DESCRIPTION
Some feedback from the Eleventy Discord; it was mentioned that, from the homepage, it looks like Vento's main feature is the syntax change. This is not really accurate, as Vento has many things going for it that go beyond just being syntactically nicer to write. I've written what I think are the four main selling points; this includes the syntax change, but is last on the list.