### PR TITLE
Strict mode

### DIFF
--- a/bench/setup.ts
+++ b/bench/setup.ts
@@ -70,6 +70,15 @@ const initializers = {
     };
   },
 
+  async VentoStrict(): Promise<Renderer> {
+    const env = vento({ autoDataVarname: true, strict: true });
+    const render = await env.load(dir + "tmp.strict.vto");
+    return async (data: Record<string, unknown>) => {
+      const { content } = await render(data);
+      return content;
+    };
+  },
+
   Nunjucks(): Renderer {
     const loader = new nunjucks.FileSystemLoader(Deno.cwd());
     const env = new nunjucks.Environment(loader);

--- a/bench/templates/tmp.strict.vto
+++ b/bench/templates/tmp.strict.vto
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width,initial-scale=1">
+	<title>{{ title }}</title>
+	<meta name="description" content="{{ description }}">
+	<meta name="robots" content="noindex,nofollow">
+</head>
+<body>
+	<nav id="navigation-menu">
+		{{ for { url, text } of mainNavItems }}
+			<a href="{{ url }}">{{ text |> toUpperCase() }}</a>
+		{{ /for }}
+	</nav>
+
+	<main>
+		<h1>Hello {{ (typeof user == 'undefined' ? {} : user).name ?? 'there' }}!</h1>
+		<p>You're looking at a page that is written exclusively for benchmarking purposes.</p>
+		<p>A bit of explanation: this benchmark is run in two different ways.</p>
+		<ul>
+			<li>The template <em>compilation</em> is measured. This indicates how fast the templating engine can turn a file like this in a reusable function. Usually, contentful templates like this are only compiled once, but for layouts or includes/partials, they are often rendered many times with different input data.</li>
+			<li>That segues nicely into the next benchmark; the speed of said reusable function. How fast does the compiled function spit out the rendered output when called with some set of properties?</li>
+		</ul>
+		<p>In order to test the speed of the templating languages themselves, here's a binary search implementation.</p>
+
+		{{ set searchTarget = 23 }}
+		<input readonly value="{{ searchTarget }}">
+		{{>
+			let start = 0
+			let end = searchArray.length
+			while(start < end - 1){
+				const middle = Math.floor(start + (end - start) / 2)
+				if(searchTarget < searchArray[middle]){
+					end = middle
+				} else {
+					start = middle
+				}
+			}
+			const targetIndex = start
+		}}
+		Output: <output>{{ targetIndex }}</output>
+
+		<p>This templating language uses <code>{&#x7B;</code> and <code>}}</code> for interpolation. There are two main ways to escape them if you need them literally:</p>
+
+		<ol>
+			<li>Through <code>{{ echo }}{{ echo }} … {{{{ /echo }} /echo }}</code>, or</li>
+			<li>Through character escaping, such as <code>{&amp;#x7B; … }}</code> in HTML.</li>
+		</ol>
+	</main>
+</body>
+</html>

--- a/core/environment.ts
+++ b/core/environment.ts
@@ -145,17 +145,16 @@ export class Environment {
     const { dataVarname, autoDataVarname, strict } = this.options;
 
     if (strict && autoDataVarname) {
+      const innerCode = JSON.stringify(`
+        const __exports = { content: "" };
+        ${code}
+        return __exports;
+      `);
       code = `
         return new Function(
           "__env",
           \`{\${Object.keys(${dataVarname}).join(",")}}\`,
-          ${
-        JSON.stringify(`
-            const __exports = { content: "" };
-            ${code}
-            return __exports;
-          `)
-      }
+          ${innerCode}
         )(__env, ${dataVarname});
       `;
     } else if (autoDataVarname) {

--- a/core/environment.ts
+++ b/core/environment.ts
@@ -153,9 +153,10 @@ export class Environment {
       code = `
         return new Function(
           "__env",
+          "${dataVarname}",
           \`{\${Object.keys(${dataVarname}).join(",")}}\`,
           ${innerCode}
-        )(__env, ${dataVarname});
+        )(__env, ${dataVarname}, ${dataVarname});
       `;
     } else if (autoDataVarname) {
       const generator = iterateTopLevel(code);

--- a/core/environment.ts
+++ b/core/environment.ts
@@ -144,18 +144,20 @@ export class Environment {
 
     const { dataVarname, autoDataVarname, strict } = this.options;
 
-    if (strict && autoDataVarname){
+    if (strict && autoDataVarname) {
       code = `
         return new Function(
           "__env",
           \`{\${Object.keys(${dataVarname}).join(",")}}\`,
-          ${JSON.stringify(`
+          ${
+        JSON.stringify(`
             const __exports = { content: "" };
             ${code}
             return __exports;
-          `)}
+          `)
+      }
         )(__env, ${dataVarname});
-      `
+      `;
     } else if (autoDataVarname) {
       const generator = iterateTopLevel(code);
       const [, , variables] = generator.next().value;

--- a/mod.ts
+++ b/mod.ts
@@ -7,6 +7,7 @@ export interface Options {
   autoDataVarname?: boolean;
   dataVarname?: string;
   autoescape?: boolean;
+  strict?: boolean;
 }
 
 export default function (options: Options = {}): Environment {
@@ -21,6 +22,7 @@ export default function (options: Options = {}): Environment {
     dataVarname: options.dataVarname || "it",
     autoescape: options.autoescape ?? false,
     autoDataVarname: options.autoDataVarname ?? true,
+    strict: options.strict ?? false,
   });
 
   // Register the default plugins

--- a/plugins/set.ts
+++ b/plugins/set.ts
@@ -21,7 +21,7 @@ function setTag(
   }
 
   const expression = code.replace(/^set\s+/, "");
-  const { dataVarname, strict } = env.options;
+  const { dataVarname } = env.options;
 
   // Value is set (e.g. {{ set foo = "bar" }})
   if (expression.includes("=")) {
@@ -34,7 +34,6 @@ function setTag(
     const [, variable, value] = match;
     const val = env.compileFilters(tokens, value);
 
-    if (strict) return `var ${variable} = ${val};`;
     return `var ${variable} = ${dataVarname}["${variable}"] = ${val};`;
   }
 
@@ -46,7 +45,6 @@ function setTag(
 
   compiled.push(`${subvarName} = "";`);
   compiled.push(...env.compileTokens(tokens, subvarName, "/set"));
-  if (strict) compiled.push(`var ${varName} = ${compiledFilters};`);
-  else compiled.push(`var ${varName} = ${subvarName} = ${compiledFilters};`);
+  compiled.push(`var ${varName} = ${subvarName} = ${compiledFilters};`);
   return compiled.join("\n");
 }

--- a/plugins/set.ts
+++ b/plugins/set.ts
@@ -21,7 +21,7 @@ function setTag(
   }
 
   const expression = code.replace(/^set\s+/, "");
-  const { dataVarname } = env.options;
+  const { dataVarname, strict } = env.options;
 
   // Value is set (e.g. {{ set foo = "bar" }})
   if (expression.includes("=")) {
@@ -34,6 +34,7 @@ function setTag(
     const [, variable, value] = match;
     const val = env.compileFilters(tokens, value);
 
+    if (strict) return `var ${variable} = ${val};`
     return `var ${variable} = ${dataVarname}["${variable}"] = ${val};`;
   }
 
@@ -45,6 +46,7 @@ function setTag(
 
   compiled.push(`${subvarName} = "";`);
   compiled.push(...env.compileTokens(tokens, subvarName, "/set"));
-  compiled.push(`var ${varName} = ${subvarName} = ${compiledFilters};`);
+  if (strict) compiled.push(`var ${varName} = ${compiledFilters};`);
+  else compiled.push(`var ${varName} = ${subvarName} = ${compiledFilters};`);
   return compiled.join("\n");
 }

--- a/plugins/set.ts
+++ b/plugins/set.ts
@@ -34,7 +34,7 @@ function setTag(
     const [, variable, value] = match;
     const val = env.compileFilters(tokens, value);
 
-    if (strict) return `var ${variable} = ${val};`
+    if (strict) return `var ${variable} = ${val};`;
     return `var ${variable} = ${dataVarname}["${variable}"] = ${val};`;
   }
 

--- a/test/echo.test.ts
+++ b/test/echo.test.ts
@@ -84,7 +84,6 @@ Deno.test("Echo tag", async () => {
     template: `
     Hello {{ world }}
     `,
-    expected: "Hello world",
     data: {
       world: "world",
     },

--- a/test/print.test.ts
+++ b/test/print.test.ts
@@ -249,3 +249,13 @@ Deno.test({
     });
   },
 });
+
+Deno.test({
+  name: "Print undeclared variable",
+  fn: async () => {
+    await test({
+      template: `{{ foo }}`,
+      expected: "",
+    });
+  },
+});

--- a/test/strict.test.ts
+++ b/test/strict.test.ts
@@ -1,0 +1,58 @@
+import { test, testThrows } from "./utils.ts";
+
+Deno.test("Strict variables", async () => {
+  await testThrows({
+    options: { strict: true },
+    template: `
+      {{ hello }}
+    `,
+  });
+  await test({
+    options: { strict: true },
+    template: `
+    {{ if false }}{{ hello }}{{ /if }}
+    `,
+    expected: "",
+  });
+  await testThrows({
+    options: { strict: true },
+    template: `
+    {{ if true }}
+      {{> const hello = 'world' }}
+    {{ /if }}
+    {{ hello }}
+    `,
+  });
+  await test({
+    options: { strict: true },
+    template: `
+    {{ if true }}
+      {{> const hello = 'world' }}
+      Hello {{ hello }}
+    {{ /if }}
+    `,
+    expected: "Hello world"
+  });
+  await test({
+    options: { strict: true },
+    template: `
+      {{ message }}
+    `,
+    data: { message: "Hello world" },
+    expected: "Hello world"
+  });
+  await testThrows({
+    options: { strict: true },
+    template: `
+      {{> it.message = "Hello world" }}
+    `,
+  });
+  await test({
+    options: { strict: true },
+    template: `
+      {{ set message = "Hello world" }}
+      {{ message }}
+    `,
+    expected: "Hello world",
+  });
+});

--- a/test/strict.test.ts
+++ b/test/strict.test.ts
@@ -31,7 +31,7 @@ Deno.test("Strict variables", async () => {
       Hello {{ hello }}
     {{ /if }}
     `,
-    expected: "Hello world"
+    expected: "Hello world",
   });
   await test({
     options: { strict: true },
@@ -39,7 +39,7 @@ Deno.test("Strict variables", async () => {
       {{ message }}
     `,
     data: { message: "Hello world" },
-    expected: "Hello world"
+    expected: "Hello world",
   });
   await testThrows({
     options: { strict: true },

--- a/test/strict.test.ts
+++ b/test/strict.test.ts
@@ -41,12 +41,6 @@ Deno.test("Strict variables", async () => {
     data: { message: "Hello world" },
     expected: "Hello world",
   });
-  await testThrows({
-    options: { strict: true },
-    template: `
-      {{> it.message = "Hello world" }}
-    `,
-  });
   await test({
     options: { strict: true },
     template: `

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -20,8 +20,10 @@ export interface TestOptions {
   options?: Options;
 }
 
-export async function testThrows(options: TestOptions) {
-  await assertRejects(async () => await test(options));
+export async function testThrows(
+  options: Omit<TestOptions, 'expected'>,
+) {
+  await assertRejects(async () => await test({...options, expected: ""}));
 }
 
 export async function test(options: TestOptions) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -21,9 +21,9 @@ export interface TestOptions {
 }
 
 export async function testThrows(
-  options: Omit<TestOptions, 'expected'>,
+  options: Omit<TestOptions, "expected">,
 ) {
-  await assertRejects(async () => await test({...options, expected: ""}));
+  await assertRejects(async () => await test({ ...options, expected: "" }));
 }
 
 export async function test(options: TestOptions) {


### PR DESCRIPTION
This mode, which only makes sense when `autoDataVarname` is `true`, throws an error when an undeclared variable is used in a template. Currently Vento does not throw when doing something like `{{ foo }}` no matter whether not `foo` is declared (and renders nothing if it is undeclared/nullish). This can be problematic because typos can go unnoticed.

Resolves https://github.com/ventojs/vento/issues/101.

I've also added a separate benchmark for the strict mode. It uses a separate template, since the default Vento template references a `user` variable that doesn't exist and this throws in strict mode. Notably, the strict mode outperforms non-strict Vento in compilation and full benchmarks, because it skips iterating the template for variable name collection. It does lose by a lot in terms of rendering speed (I'm seeing a 10x slowdown here locally) but non-strict Vento is insanely fast to render so the benefit in compilation speed still outweighs the slowdown in rendering for the compilation and full benchmarks.

Needs a bit more testing before merging, but looks like the strategy works okay in general.