### PR TITLE
Silence the linter about import specifiers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,11 @@
     "build-npm": "deno run --allow-run --allow-read --allow-write _scripts/build_npm.ts"
   },
   "lock": false,
+  "lint": {
+    "rules": {
+      "exclude": ["no-import-prefix"]
+    },
+  },
   "fmt": {
     "exclude": [
       "CHANGELOG.md",


### PR DESCRIPTION
This is currently blocking the workflows since Deno has decided they don't like this.