### PR TITLE
Fix static content after function being removed

### DIFF
--- a/plugins/function.ts
+++ b/plugins/function.ts
@@ -41,8 +41,6 @@ function functionTag(
     compiled.push(...env.compileTokens(tokens, "__output", "/function"));
   }
 
-  tokens.shift();
-
   compiled.push(`return __env.utils.safeString(${result});`);
   compiled.push(`}`);
 

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -222,7 +222,7 @@ Deno.test("Function with complex arguments", async () => {
   });
 });
 
-Deno.test('Static content after a function declaration', async () => {
+Deno.test("Static content after a function declaration", async () => {
   await test({
     template: `
     {{ function foo }}{{ /function }}
@@ -230,8 +230,8 @@ Deno.test('Static content after a function declaration', async () => {
     `,
     expected: "Hello world!",
     data: {
-      target: 'world',
-      punctuation: '!',
+      target: "world",
+      punctuation: "!",
     },
-  })
-})
+  });
+});

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -221,3 +221,17 @@ Deno.test("Function with complex arguments", async () => {
     expected: "Hello world (hi)",
   });
 });
+
+Deno.test('Static content after a function declaration', async () => {
+  await test({
+    template: `
+    {{ function foo }}{{ /function }}
+    Hello {{ target }}{{ punctuation }}
+    `,
+    expected: "Hello world!",
+    data: {
+      target: 'world',
+      punctuation: '!',
+    },
+  })
+})


### PR DESCRIPTION
I guess the `tokens.shift()` is a historical artifact, not sure - presumably this managed to go under the radar all this time just because the function declarations were being followed up by other tags or interpolation.

Fixes https://github.com/ventojs/vento/issues/147