### PR TITLE
Make closing {{ /layout }} tag optional

### DIFF
--- a/core/environment.ts
+++ b/core/environment.ts
@@ -258,6 +258,7 @@ export class Environment {
     tokens: Token[],
     outputVar = "__exports.content",
     closeToken?: string,
+    closeTokenOptional = false
   ): string[] {
     const compiled: string[] = [];
     let openToken: Token | undefined;
@@ -309,7 +310,7 @@ export class Environment {
     }
 
     // If we reach here, it means we have an open token that wasn't closed
-    if (closeToken) {
+    if (closeToken && !closeTokenOptional) {
       throw new SourceError(
         `Missing closing tag ("${closeToken}" tag is expected)`,
         openToken![2],

--- a/plugins/layout.ts
+++ b/plugins/layout.ts
@@ -35,7 +35,7 @@ function layoutTag(
   const { dataVarname } = env.options;
   return `${output} += (await (async () => {
     const __slots = { content: "" };
-    ${env.compileTokens(tokens, "__slots.content", "/layout").join("\n")}
+    ${env.compileTokens(tokens, "__slots.content", "/layout", true).join("\n")}
     __slots.content = __env.utils.safeString(${compiledFilters});
     return __env.run(${file}, {
       ...${dataVarname},

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -219,3 +219,39 @@ Deno.test("Layouts with slots", async () => {
     },
   });
 });
+
+Deno.test("Layouts without closing tag", async () => {
+  await test({
+    template: `
+    {{ layout "/my-file.vto" }}
+    world
+    {{ slot greeting }}Hello{{ /slot }}
+    `,
+    expected: "Hello world",
+    includes: {
+      "/my-file.vto": "{{ greeting }} {{ content |> trim }}",
+    },
+  });
+  await test({
+    template: `
+    {{ layout "/my-file.vto" }}
+    Hello {{ layout "/em.vto" }}world{{ /layout }}!
+    `,
+    expected: "<p>Hello <em>world</em>!</p>",
+    includes: {
+      "/my-file.vto": "<p>{{ content |> trim }}</p>",
+      "/em.vto": "<em>{{ content }}</em>",
+    },
+  });
+  await test({
+    template: `
+    {{ layout "/my-file.vto" -}}
+    Hello {{ layout "/em.vto" }}world
+    `,
+    expected: "<p>Hello <em>world</em></p>",
+    includes: {
+      "/my-file.vto": "<p>{{ content |> trim }}</p>",
+      "/em.vto": "<em>{{ content |> trim }}</em>",
+    },
+  });
+});


### PR DESCRIPTION
In this approach I add an argument to the `compileTokens()` function, to allow for an optional end token.

The alternative, adding an extra `{{ /layout }}` token to the `tokens` array within the layout plugin, ends up being quite complex. This is because if there are two unclosed `{{ layout }}` tags, then inserting the implied `{{ /layout }}` token actually gets eaten by the second layout tag, and the first layout tag then _still_ ends up throwing an error about being unclosed. Additionally, we probably want to also remove the inserted end token if it wasn't used. Altogether I felt that this way of doing it would get needlessly complicated.

Resolves https://github.com/ventojs/vento/issues/145
