### PR TITLE
Strict mode is not slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.1.0] - Unreleased
 ### Added
-- New `strict` mode to fail when using an undefined variable. This mode is much more slower than normal mode, so it's intended only for testing and debug purposes. [#101], [#142]
+- New `strict` mode to fail when using an undefined variable. This mode has a different performance profile than normal mode; it's mostly intended for testing and debug purposes. [#101], [#142]
 
 ## [2.0.2] - 2025-09-13
 ### Added

--- a/core/environment.ts
+++ b/core/environment.ts
@@ -151,12 +151,13 @@ export class Environment {
         return __exports;
       `);
       code = `
-        return new Function(
+        return new (async function(){}).constructor(
           "__env",
+          "__template",
           "${dataVarname}",
           \`{\${Object.keys(${dataVarname}).join(",")}}\`,
           ${innerCode}
-        )(__env, ${dataVarname}, ${dataVarname});
+        )(__env, __template, ${dataVarname}, ${dataVarname});
       `;
     } else if (autoDataVarname) {
       const generator = iterateTopLevel(code);

--- a/test/strict.test.ts
+++ b/test/strict.test.ts
@@ -62,4 +62,4 @@ Deno.test("Includes still work", async () => {
       "/my-file.vto": "Hello world",
     },
   });
-})
+});

--- a/test/strict.test.ts
+++ b/test/strict.test.ts
@@ -50,3 +50,16 @@ Deno.test("Strict variables", async () => {
     expected: "Hello world",
   });
 });
+
+Deno.test("Includes still work", async () => {
+  await test({
+    options: { strict: true },
+    template: `
+    {{ include "/my-file.vto" }}
+    `,
+    expected: "Hello world",
+    includes: {
+      "/my-file.vto": "Hello world",
+    },
+  });
+})


### PR DESCRIPTION
Of course this is a bit minor, but I don't think it's accurate to say it's "much slower". The performance profile is different, but in some cases it actually ends up being _faster_ than Vento's default. Template compilation specifically is faster than usual because the generated JavaScript doesn't need to be iterated over to look for variable names. It's much slower in rendering, because it has to re-compile a new JS function every render, but rendering overall is already orders of magnitude faster than compilation, so this slowdown actually doesn't make it slower overall. For projects that have a lot of templates being rendered only once, the strict mode may prove to be faster.

I tried strict mode in lume.land's website, and (with some minor modifications to get around undefined variables) it ends up building in about 5.8s on my machine (averagish over three runs) whereas non-strict mode builds in about 5.9s. That's a very minor difference, maybe even insignificant, but at least shows that strict mode doesn't have to be slow.

While trying to get strict mode running for lume.land's site, I discovered some (pretty critical) issues; this PR also includes fixes and a test for those.