### PR TITLE
Fix variable detection with spread operator

### DIFF
--- a/core/js.ts
+++ b/core/js.ts
@@ -2,7 +2,7 @@ import reserved from "./reserved.ts";
 
 const TEMPLATE_PART = /[`}](?:\\?[^])*?(?:`|\${)/y;
 const REGEX_LITERAL_START = /(?<=[(=:,?&!]\s*)\//y;
-const STOPPING_POINT = /['"`{}[\]/|]|((?<!\.\??)\b[a-zA-Z_]\w*)/g;
+const STOPPING_POINT = /['"`{}[\]/|]|(((?<=\.\.\.)|(?<!\.\??))\b[a-zA-Z_]\w*)/g;
 
 /**
  * This function iterates over the top-level scope of a JavaScript source code

--- a/test/js.test.ts
+++ b/test/js.test.ts
@@ -123,4 +123,12 @@ Deno.test("> tag", async () => {
     template: "{{ `{${`${`a`}`}}` }}",
     expected: "{a}",
   });
+
+  await test({
+    template: "{{ {...foo} |> JSON.stringify }}",
+    data: {
+      foo: { bar: 23 },
+    },
+    expected: `{"bar":23}`,
+  });
 });


### PR DESCRIPTION
Templates that only include a variable used after a spread operator fail to detect the variable since it is instead falsely detected as property access (i.e. `.foo`). We should make sure that if we see `.foo` that it is not `...foo`, since in the latter case we do need to include it.