### PR TITLE
Create unique temp variables

### DIFF
--- a/core/environment.ts
+++ b/core/environment.ts
@@ -67,7 +67,7 @@ export class Environment {
   tags: Tag[] = [];
   tokenPreprocessors: TokenPreprocessor[] = [];
   filters: Record<string, Filter> = {};
-  #tempVariablesCreated = 0
+  #tempVariablesCreated = 0;
   utils: Record<string, unknown> = {
     callMethod,
     createError,
@@ -387,12 +387,11 @@ export class Environment {
   }
 
   getTempVariable(): string {
-    const id = this.#tempVariablesCreated
-    const variable = `__tmp${id}`
-    this.#tempVariablesCreated++
-    return variable
+    const id = this.#tempVariablesCreated;
+    const variable = `__tmp${id}`;
+    this.#tempVariablesCreated++;
+    return variable;
   }
-
 }
 
 function isGlobal(name: string) {

--- a/core/environment.ts
+++ b/core/environment.ts
@@ -67,6 +67,7 @@ export class Environment {
   tags: Tag[] = [];
   tokenPreprocessors: TokenPreprocessor[] = [];
   filters: Record<string, Filter> = {};
+  #tempVariablesCreated = 0
   utils: Record<string, unknown> = {
     callMethod,
     createError,
@@ -384,6 +385,14 @@ export class Environment {
 
     return output;
   }
+
+  getTempVariable(): string {
+    const id = this.#tempVariablesCreated
+    const variable = `__tmp${id}`
+    this.#tempVariablesCreated++
+    return variable
+  }
+
 }
 
 function isGlobal(name: string) {

--- a/plugins/echo.ts
+++ b/plugins/echo.ts
@@ -25,7 +25,7 @@ function echoTag(
   }
 
   // Captured echo, e.g. {{ echo |> toUpperCase }} foo {{ /echo }}
-  const tmp = env.getTempVariable()
+  const tmp = env.getTempVariable();
   const compiled = [`let ${tmp} = "";`];
   const filters = env.compileFilters(tokens, tmp);
   compiled.push(...env.compileTokens(tokens, tmp, "/echo"));

--- a/plugins/echo.ts
+++ b/plugins/echo.ts
@@ -25,16 +25,17 @@ function echoTag(
   }
 
   // Captured echo, e.g. {{ echo |> toUpperCase }} foo {{ /echo }}
-  const compiled = [`let __tmp = "";`];
-  const filters = env.compileFilters(tokens, "__tmp");
-  compiled.push(...env.compileTokens(tokens, "__tmp", "/echo"));
+  const tmp = env.getTempVariable()
+  const compiled = [`let ${tmp} = "";`];
+  const filters = env.compileFilters(tokens, tmp);
+  compiled.push(...env.compileTokens(tokens, tmp, "/echo"));
 
-  if (filters != "__tmp") {
-    compiled.push(`__tmp = ${filters}`);
+  if (filters != tmp) {
+    compiled.push(`${tmp} = ${filters}`);
   }
 
   return `{
     ${compiled.join("\n")}
-    ${output} += __tmp;
+    ${output} += ${tmp};
   }`;
 }

--- a/plugins/function.ts
+++ b/plugins/function.ts
@@ -32,13 +32,14 @@ function functionTag(
 
   const compiled: string[] = [];
   compiled.push(`${as || ""} function ${name} ${args || "()"} {`);
-  compiled.push(`let __output = "";`);
-  const result = env.compileFilters(tokens, "__output");
+  const tmp = env.getTempVariable()
+  compiled.push(`let ${tmp} = "";`);
+  const result = env.compileFilters(tokens, tmp);
 
   if (exp) {
-    compiled.push(...env.compileTokens(tokens, "__output", "/export"));
+    compiled.push(...env.compileTokens(tokens, tmp, "/export"));
   } else {
-    compiled.push(...env.compileTokens(tokens, "__output", "/function"));
+    compiled.push(...env.compileTokens(tokens, tmp, "/function"));
   }
 
   compiled.push(`return __env.utils.safeString(${result});`);

--- a/plugins/function.ts
+++ b/plugins/function.ts
@@ -32,7 +32,7 @@ function functionTag(
 
   const compiled: string[] = [];
   compiled.push(`${as || ""} function ${name} ${args || "()"} {`);
-  const tmp = env.getTempVariable()
+  const tmp = env.getTempVariable();
   compiled.push(`let ${tmp} = "";`);
   const result = env.compileFilters(tokens, tmp);
 

--- a/plugins/import.ts
+++ b/plugins/import.ts
@@ -32,10 +32,11 @@ function importTag(
   const [, identifiers, specifier] = match;
 
   const defaultImport = identifiers.match(DEFAULT_IMPORT);
+  const tmp = env.getTempVariable()
   if (defaultImport) {
     const [name] = defaultImport;
     variables.push(name);
-    compiled.push(`${name} = __tmp;`);
+    compiled.push(`${name} = ${tmp};`);
   } else {
     const namedImports = identifiers.match(NAMED_IMPORTS);
     if (namedImports) {
@@ -54,7 +55,7 @@ function importTag(
           throw new SourceError("Invalid named import", position);
         }
       });
-      compiled.push(`({${chunks.join(",")}} = __tmp);`);
+      compiled.push(`({${chunks.join(",")}} = ${tmp});`);
     } else {
       throw new SourceError("Invalid import tag", position);
     }
@@ -62,7 +63,7 @@ function importTag(
 
   const { dataVarname } = env.options;
   return `let ${variables.join(",")}; {
-    let __tmp = await __env.run(${specifier}, {...${dataVarname}}, __template.path, ${position});
+    let ${tmp} = await __env.run(${specifier}, {...${dataVarname}}, __template.path, ${position});
     ${compiled.join("\n")}
   }`;
 }

--- a/plugins/import.ts
+++ b/plugins/import.ts
@@ -32,7 +32,7 @@ function importTag(
   const [, identifiers, specifier] = match;
 
   const defaultImport = identifiers.match(DEFAULT_IMPORT);
-  const tmp = env.getTempVariable()
+  const tmp = env.getTempVariable();
   if (defaultImport) {
     const [name] = defaultImport;
     variables.push(name);

--- a/plugins/include.ts
+++ b/plugins/include.ts
@@ -38,12 +38,13 @@ function includeTag(
   }
 
   const { dataVarname } = env.options;
+  const tmp = env.getTempVariable()
   return `{
-    const __include = await __env.run(${file},
+    const ${tmp} = await __env.run(${file},
       {...${dataVarname}${data ? `, ...${data}` : ""}},
       __template.path,
       ${position}
     );
-    ${output} += ${env.compileFilters(tokens, "__include.content")};
+    ${output} += ${env.compileFilters(tokens, `${tmp}.content`)};
   }`;
 }

--- a/plugins/include.ts
+++ b/plugins/include.ts
@@ -38,7 +38,7 @@ function includeTag(
   }
 
   const { dataVarname } = env.options;
-  const tmp = env.getTempVariable()
+  const tmp = env.getTempVariable();
   return `{
     const ${tmp} = await __env.run(${file},
       {...${dataVarname}${data ? `, ...${data}` : ""}},

--- a/plugins/layout.ts
+++ b/plugins/layout.ts
@@ -62,10 +62,11 @@ function slotTag(
     throw new SourceError(`Invalid slot name "${name}"`, position);
   }
 
-  const compiledFilters = env.compileFilters(tokens, "__tmp");
+  const tmp = env.getTempVariable()
+  const compiledFilters = env.compileFilters(tokens, tmp);
   return `{
-    let __tmp = '';
-    ${env.compileTokens(tokens, "__tmp", "/slot").join("\n")}
+    let ${tmp} = '';
+    ${env.compileTokens(tokens, tmp, "/slot").join("\n")}
     __slots.${name} ??= '';
     __slots.${name} += ${compiledFilters};
     __slots.${name} = __env.utils.safeString(__slots.${name});

--- a/plugins/layout.ts
+++ b/plugins/layout.ts
@@ -62,7 +62,7 @@ function slotTag(
     throw new SourceError(`Invalid slot name "${name}"`, position);
   }
 
-  const tmp = env.getTempVariable()
+  const tmp = env.getTempVariable();
   const compiledFilters = env.compileFilters(tokens, tmp);
   return `{
     let ${tmp} = '';

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -253,6 +253,21 @@ Deno.test("Layouts with slots", async () => {
       "/nav.vto": "<a>Nav</a>",
     },
   });
+  await test({
+    template: `
+    {{ layout "/base.vto" }}
+      {{ slot greeting |> toLowerCase }}
+        {{ echo |> toUpperCase }}
+          Hello world
+        {{ /echo }}
+      {{ /slot }}
+    {{ /layout }}
+    `,
+    expected: "hello world",
+    includes: {
+      "/base.vto": "{{ greeting |> trim }}",
+    },
+  })
 });
 
 Deno.test("Layouts without closing tag", async () => {

--- a/test/layout.test.ts
+++ b/test/layout.test.ts
@@ -267,7 +267,7 @@ Deno.test("Layouts with slots", async () => {
     includes: {
       "/base.vto": "{{ greeting |> trim }}",
     },
-  })
+  });
 });
 
 Deno.test("Layouts without closing tag", async () => {


### PR DESCRIPTION
Adds a `env.getTempVariable()` method that creates a unique variable name for use in plugins. Also replaces some temp variable usage in existing core plugins.

The idea I had with `env.createScope()` didn't really work because it is incompatible with the way functions are built up as strings in Vento. I would like to, at some point, try to improve the plugin development experience, but for now this'll do just fine.