### PR TITLE
Support for destructuring in set

### DIFF
--- a/plugins/set.ts
+++ b/plugins/set.ts
@@ -37,16 +37,7 @@ function setTag(
     const value = match[2].trim();
     const val = env.compileFilters(tokens, value);
 
-    let open: string | undefined, close: string | undefined;
-    if (variable.startsWith("{")) {
-      open = "{";
-      close = "}";
-    } else if (variable.startsWith("[")) {
-      open = "[";
-      close = "]";
-    }
-
-    if (open && close) {
+    if (variable.startsWith("{") || variable.startsWith("[")) {
       const code = [`var ${variable} = ${val};`];
 
       for (const [name] of variable.matchAll(DETECTED_VARS)) {

--- a/plugins/set.ts
+++ b/plugins/set.ts
@@ -8,6 +8,7 @@ export default function (): Plugin {
   };
 }
 
+const VARNAME = /^[a-zA-Z_]\w*$/;
 const DETECTED_VARS = /([a-zA-Z_]\w*)\b(?!\s*\:)/g;
 
 function setTag(
@@ -37,13 +38,19 @@ function setTag(
     const value = match[2].trim();
     const val = env.compileFilters(tokens, value);
 
-    if (variable.startsWith("{") || variable.startsWith("[")) {
+    if (
+      (variable.startsWith("{") && variable.endsWith("}")) ||
+      (variable.startsWith("[") && variable.endsWith("]"))
+    ) {
       const names = Array.from(variable.matchAll(DETECTED_VARS))
         .map((n) => n[1]);
       return `
         var ${variable} = ${val};
         Object.assign(${dataVarname}, { ${names.join(", ")} });
       `;
+    }
+    if (!VARNAME.test(variable)) {
+      throw new SourceError("Invalid variable name", position);
     }
 
     return `var ${variable} = ${dataVarname}["${variable}"] = ${val};`;

--- a/plugins/set.ts
+++ b/plugins/set.ts
@@ -38,13 +38,12 @@ function setTag(
     const val = env.compileFilters(tokens, value);
 
     if (variable.startsWith("{") || variable.startsWith("[")) {
-      const code = [`var ${variable} = ${val};`];
-
-      for (const [name] of variable.matchAll(DETECTED_VARS)) {
-        code.push(`${dataVarname}["${name}"] = ${name};`);
-      }
-
-      return code.join("\n");
+      const names = Array.from(variable.matchAll(DETECTED_VARS))
+        .map((n) => n[1]);
+      return `
+        var ${variable} = ${val};
+        Object.assign(${dataVarname}, { ${names.join(", ")} });
+      `;
     }
 
     return `var ${variable} = ${dataVarname}["${variable}"] = ${val};`;

--- a/plugins/set.ts
+++ b/plugins/set.ts
@@ -1,4 +1,5 @@
 import { SourceError } from "../core/errors.ts";
+import iterateTopLevel from "../core/js.ts";
 import type { Token } from "../core/tokenizer.ts";
 import type { Environment, Plugin } from "../core/environment.ts";
 
@@ -25,14 +26,43 @@ function setTag(
 
   // Value is set (e.g. {{ set foo = "bar" }})
   if (expression.includes("=")) {
-    const match = code.match(/^set\s+([\w]+)\s*=\s*([\s\S]+)$/);
+    const match = code.match(/^set\s+([\w{}[\]\s,:]+)\s*=\s*([\s\S]+)$/);
 
     if (!match) {
       throw new SourceError("Invalid set tag", position);
     }
 
-    const [, variable, value] = match;
+    const variable = match[1].trim();
+    const value = match[2].trim();
     const val = env.compileFilters(tokens, value);
+
+    let open: string | undefined, close: string | undefined;
+    if (variable.startsWith("{")) {
+      open = "{";
+      close = "}";
+    } else if (variable.startsWith("[")) {
+      open = "[";
+      close = "]";
+    }
+
+    if (open && close) {
+      for (const [, reason, vars] of iterateTopLevel(variable)) {
+        if (reason === open) continue;
+        if (reason !== close) {
+          throw new SourceError("Invalid set tag, unclosed bracket", position);
+        }
+
+        const declaredVars = vars.values()
+          .toArray()
+          .map((name) => `${dataVarname}["${name}"] = ${name};`)
+          .join("\n");
+
+        return `
+          var ${variable} = ${val};
+          ${declaredVars}
+        `;
+      }
+    }
 
     return `var ${variable} = ${dataVarname}["${variable}"] = ${val};`;
   }

--- a/test/set.test.ts
+++ b/test/set.test.ts
@@ -172,6 +172,22 @@ Deno.test("Set with destructuring variables", async () => {
 
   await test({
     template: `
+    {{ set { one, ...other } = { one: 1, two: 2, three: 3 } }}
+    {{ one }} {{ other.two }} {{ other.three }}
+    `,
+    expected: "1 2 3",
+  });
+
+  await test({
+    template: `
+    {{ set { foo, bar: bar2 } = { foo: "foo", bar: "bar" } }}
+    {{ foo }} {{ bar2 }}
+    `,
+    expected: "foo bar",
+  });
+
+  await test({
+    template: `
     {{ set [one, two] = ["one", "two"] }}
     {{ one }} {{ two }}
     `,
@@ -192,5 +208,28 @@ Deno.test("Set with destructuring variables", async () => {
     {{ x }} {{ y }} {{ z }}
     `,
     expected: "X Y Z",
+  });
+
+  await test({
+    template: `
+    {{ set { a, b: { c, d } } = { a: "A", b: { c: "C", d: "D" } } }}
+    {{ a }} {{ c }} {{ d }}
+    `,
+    options: {
+      autoDataVarname: false,
+    },
+    expected: "A C D",
+  });
+
+  await test({
+    template: `
+      {{> const foo = 'local' }}
+      {{ set { foo: [bar] } = { foo: [23] } }}
+      {{ include "./maybe-foo.vto" }}
+    `,
+    includes: {
+      "/maybe-foo.vto": `Should not print anything: {{ foo }}`,
+    },
+    expected: "Should not print anything:",
   });
 });

--- a/test/set.test.ts
+++ b/test/set.test.ts
@@ -160,3 +160,37 @@ Deno.test("Set tag in a loop", async () => {
     },
   });
 });
+
+Deno.test("Set with destructuring variables", async () => {
+  await test({
+    template: `
+    {{ set { foo, bar } = { foo: "foo", bar: "bar" } }}
+    {{ foo }} {{ bar }}
+    `,
+    expected: "foo bar",
+  });
+
+  await test({
+    template: `
+    {{ set [one, two] = ["one", "two"] }}
+    {{ one }} {{ two }}
+    `,
+    expected: "one two",
+  });
+
+  await test({
+    template: `
+    {{ set { a, b: { c, d } } = { a: "A", b: { c: "C", d: "D" } } }}
+    {{ a }} {{ c }} {{ d }}
+    `,
+    expected: "A C D",
+  });
+
+  await test({
+    template: `
+    {{ set [x, [y, z]] = ["X", ["Y", "Z"]] }}
+    {{ x }} {{ y }} {{ z }}
+    `,
+    expected: "X Y Z",
+  });
+});


### PR DESCRIPTION
Fixes #154

Todo:

- [x] Add support for `{ ...varname }`
- [x] Fix or remove support for colons in `{{ { foo: [bar] } = { foo: [23] }`